### PR TITLE
add bisect and colorsys to ALLOWED_IMPORTS

### DIFF
--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -149,7 +149,9 @@ BUILTIN_AST_FUNCS_FACTORY = {
 
 
 ALLOWED_IMPORTS = {
+    "bisect",
     "cmath",
+    "colorsys",
     "datetime",
     "decimal",
     "fractions",


### PR DESCRIPTION
I am trying to convert an AppDaemon app: https://github.com/basnijholt/home-assistant-config/blob/05ca9847edc2d68ae6429053d1de6e21db9c2848/appdaemon/apps/wake_up_light.py