### PR TITLE
Add config flow support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ icon
 venv
 hass-custom-pyscript.zip
 .coverage
+.vscode
 .*.swp

--- a/README.md
+++ b/README.md
@@ -59,13 +59,11 @@ this [README](https://github.com/craigbarratt/hass-pyscript-jupyter/blob/master/
 
 ## Configuration
 
-* Add `pyscript:` to `<config>/configuration.yaml`; pyscript has one optional
-configuration parameter that allows any python package to be imported if set, eg:
+* Go to the Integrations menu in the Home Assistant Configuration UI and add `Pyscript Python scripting` from there, or add `pyscript:` to `<config>/configuration.yaml`; pyscript has one optional configuration parameter that allows any python package to be imported if set, eg:
     ```yaml
     pyscript:
       allow_all_imports: true
     ```
-* Create the folder `<config>/pyscript`
 * Add files with a suffix of `.py` in the folder `<config>/pyscript`.
 * Restart HASS.
 * Whenever you change a script file, make a `reload` service call to `pyscript`.

--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -28,11 +28,11 @@ from .jupyter_kernel import Kernel
 from .state import State
 from .trigger import TrigTime
 
+_LOGGER = logging.getLogger(LOGGER_PATH)
+
 PYSCRIPT_SCHEMA = vol.Schema(
     {vol.Optional(CONF_ALLOW_ALL_IMPORTS, default=False): cv.boolean}, extra=vol.ALLOW_EXTRA,
 )
-
-_LOGGER = logging.getLogger(LOGGER_PATH)
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: PYSCRIPT_SCHEMA}, extra=vol.ALLOW_EXTRA)
 

--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -8,6 +8,7 @@ import os
 import voluptuous as vol
 
 from homeassistant.config import async_hass_config_yaml, async_process_component_config
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
@@ -18,7 +19,7 @@ from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.loader import async_get_integration, bind_hass
 
-from .const import DOMAIN, FOLDER, LOGGER_PATH, SERVICE_JUPYTER_KERNEL_START
+from .const import CONF_ALLOW_ALL_IMPORTS, DOMAIN, FOLDER, LOGGER_PATH, SERVICE_JUPYTER_KERNEL_START
 from .eval import AstEval
 from .event import Event
 from .function import Function
@@ -27,22 +28,29 @@ from .jupyter_kernel import Kernel
 from .state import State
 from .trigger import TrigTime
 
+PYSCRIPT_SCHEMA = vol.Schema(
+    {vol.Optional(CONF_ALLOW_ALL_IMPORTS, default=False): cv.boolean}, extra=vol.ALLOW_EXTRA,
+)
+
 _LOGGER = logging.getLogger(LOGGER_PATH)
 
-CONF_ALLOW_ALL_IMPORTS = "allow_all_imports"
-
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {vol.Optional(CONF_ALLOW_ALL_IMPORTS, default=False): cv.boolean}, extra=vol.ALLOW_EXTRA,
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
+CONFIG_SCHEMA = vol.Schema({DOMAIN: PYSCRIPT_SCHEMA}, extra=vol.ALLOW_EXTRA)
 
 
 async def async_setup(hass, config):
-    """Initialize the pyscript component."""
+    """Component setup, run import config flow for each entry in config."""
+    if DOMAIN in config:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_IMPORT}, data=config[DOMAIN]
+            )
+        )
+
+    return True
+
+
+async def async_setup_entry(hass, config_entry):
+    """Initialize the pyscript config entry."""
     Function.init(hass)
     Event.init(hass)
     TrigTime.init(hass)
@@ -52,19 +60,16 @@ async def async_setup(hass, config):
 
     pyscript_folder = hass.config.path(FOLDER)
 
-    def check_isdir(path):
-        return os.path.isdir(path)
-
-    if not await hass.async_add_executor_job(check_isdir, pyscript_folder):
-        _LOGGER.error("Folder %s not found in configuration folder", FOLDER)
-        return False
+    if not await hass.async_add_executor_job(os.path.isdir, pyscript_folder):
+        _LOGGER.debug("Folder %s not found in configuration folder, creating it", FOLDER)
+        await hass.async_add_executor_job(os.makedirs, pyscript_folder)
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN]["allow_all_imports"] = config[DOMAIN].get(CONF_ALLOW_ALL_IMPORTS)
+    hass.data[DOMAIN][CONF_ALLOW_ALL_IMPORTS] = config_entry.data.get(CONF_ALLOW_ALL_IMPORTS)
 
-    State.set_pyscript_config(config.get(DOMAIN, {}))
+    State.set_pyscript_config(config_entry.data)
 
-    await load_scripts(hass, config)
+    await load_scripts(hass, config_entry.data)
 
     async def reload_scripts_handler(call):
         """Handle reload service calls."""
@@ -173,6 +178,12 @@ async def async_setup(hass, config):
     hass.bus.async_listen(EVENT_HOMEASSISTANT_STARTED, start_triggers)
     hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, stop_triggers)
 
+    return True
+
+
+async def async_unload_entry(hass, config_entry):
+    """Unload a config entry."""
+    hass.data.pop(DOMAIN)
     return True
 
 

--- a/custom_components/pyscript/config_flow.py
+++ b/custom_components/pyscript/config_flow.py
@@ -1,0 +1,44 @@
+"""Config flow for Vizio."""
+import copy
+
+from homeassistant import config_entries
+
+from . import PYSCRIPT_SCHEMA
+from .const import CONF_ALLOW_ALL_IMPORTS, DOMAIN
+
+
+class PyscriptConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a pyscript config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    async def async_step_user(self, user_input):
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            if await self.async_set_unique_id(unique_id=DOMAIN, raise_on_progress=True):
+                self.async_abort(reason="single_instance_allowed")
+
+            return self.async_create_entry(title=DOMAIN, data=user_input)
+
+        return self.async_show_form(step_id="user", data_schema=PYSCRIPT_SCHEMA)
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        # Check if import config entry matches any existing config entries
+        # so we can update it if necessary
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        if entries:
+            entry = entries[0]
+            if entry.data.get(CONF_ALLOW_ALL_IMPORTS, False) != import_config.get(
+                CONF_ALLOW_ALL_IMPORTS, False
+            ):
+                updated_data = copy.copy(entry.data)
+                updated_data[CONF_ALLOW_ALL_IMPORTS] = import_config.get(CONF_ALLOW_ALL_IMPORTS, False)
+                self.hass.config_entries.async_update_entry(entry=entry, data=updated_data)
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="updated_entry")
+
+            return self.async_abort(reason="already_configured_service")
+
+        return await self.async_step_user(user_input=import_config)

--- a/custom_components/pyscript/config_flow.py
+++ b/custom_components/pyscript/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for Vizio."""
+"""Config flow for pyscript."""
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/custom_components/pyscript/const.py
+++ b/custom_components/pyscript/const.py
@@ -4,6 +4,8 @@ DOMAIN = "pyscript"
 
 FOLDER = "pyscript"
 
+CONF_ALLOW_ALL_IMPORTS = "allow_all_imports"
+
 SERVICE_JUPYTER_KERNEL_START = "jupyter_kernel_start"
 
 LOGGER_PATH = "custom_components.pyscript"

--- a/custom_components/pyscript/manifest.json
+++ b/custom_components/pyscript/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "pyscript",
   "name": "Pyscript Python scripting",
-  "config_flow": false,
+  "config_flow": true,
   "documentation": "https://github.com/custom-components/pyscript",
   "issue_tracker": "https://github.com/custom-components/pyscript/issues",
   "requirements": ["croniter==0.3.34"],

--- a/custom_components/pyscript/strings.json
+++ b/custom_components/pyscript/strings.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "pyscript",
+        "description": "Once you have created an entry, refer to the [docs](https://hacs-pyscript.readthedocs.io/en/latest/) to learn how to create scripts and functions.",
+        "data": {
+          "allow_all_imports": "Allow All Imports?"
+        }
+      }
+    },
+    "abort": {
+      "already_configured_service": "[%key:common::config_flow::abort::already_configured_service%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "updated_entry": "This entry has already been setup but the configuration has been updated."
+    }
+  }
+}

--- a/custom_components/pyscript/translations/en.json
+++ b/custom_components/pyscript/translations/en.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "pyscript",
+        "description": "Once you have created an entry, refer to the [docs](https://hacs-pyscript.readthedocs.io/en/latest/) to learn how to create scripts and functions.",
+        "data": {
+          "allow_all_imports": "Allow All Imports?"
+        }
+      }
+    },
+    "abort": {
+      "already_configured_service": "[%key:common::config_flow::abort::already_configured_service%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "updated_entry": "This entry has already been setup but the configuration has been updated."
+    }
+  }
+}

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,16 +1,16 @@
 Configuration
 =============
 
--  Add ``pyscript:`` to ``<config>/configuration.yaml``; pyscript has
-   one optional configuration parameter that allows any python package
-   to be imported if set, eg:
+-  Go to the Integrations menu in the Home Assistant Configuration UI and add
+   ``Pyscript Python scripting`` from there, or add ``pyscript:`` to 
+   ``<config>/configuration.yaml``; pyscript has one optional configuration
+   parameter that allows any python package to be imported if set, eg:
 
    .. code:: yaml
 
       pyscript:
         allow_all_imports: true
 
--  Create the folder ``<config>/pyscript``
 -  Add files with a suffix of ``.py`` in the folder ``<config>/pyscript``.
 -  Restart HASS.
 -  Whenever you change a script file, make a ``reload`` service call to ``pyscript``.

--- a/info.md
+++ b/info.md
@@ -23,8 +23,7 @@ See the documentation if you want to install pyscript manually.
 
 ## Configuration
 
-* Add `pyscript:` to `<config>/configuration.yaml`; there is one optional parameter (see docs)
-* Create the folder `<config>/pyscript`
+* Go to the Integrations menu in the Home Assistant Configuration UI and add `Pyscript Python scripting` from there, or add `pyscript:` to `<config>/configuration.yaml`; there is one optional parameter (see docs)
 * Add files with a suffix of `.py` in the folder `<config>/pyscript`.
 * Whenever you change a script file, make a `reload` service call to `pyscript`.
 * Watch the HASS log for `pyscript` errors and logger output from your scripts.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -12,14 +12,14 @@ from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 _LOGGER = logging.getLogger(__name__)
 
 
-@pytest.fixture(name="pyscript_bypass_setup")
+@pytest.fixture(name="pyscript_bypass_setup", autouse=True)
 def pyscript_bypass_setup_fixture():
     """Mock component setup."""
     with patch("custom_components.pyscript.async_setup_entry", return_value=True):
         yield
 
 
-async def test_user_flow_minimum_fields(hass, pyscript_bypass_setup):
+async def test_user_flow_minimum_fields(hass):
     """Test user config flow with minimum fields."""
     # test form shows
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": SOURCE_USER})
@@ -33,7 +33,7 @@ async def test_user_flow_minimum_fields(hass, pyscript_bypass_setup):
     assert not result["data"][CONF_ALLOW_ALL_IMPORTS]
 
 
-async def test_user_flow_all_fields(hass, pyscript_bypass_setup,) -> None:
+async def test_user_flow_all_fields(hass):
     """Test user config flow with all fields."""
     # test form shows
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": SOURCE_USER})
@@ -50,7 +50,7 @@ async def test_user_flow_all_fields(hass, pyscript_bypass_setup,) -> None:
     assert result["data"][CONF_ALLOW_ALL_IMPORTS]
 
 
-async def test_user_already_configured(hass, pyscript_bypass_setup,) -> None:
+async def test_user_already_configured(hass):
     """Test service is already configured during user setup."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data={CONF_ALLOW_ALL_IMPORTS: True}
@@ -75,7 +75,7 @@ async def test_import_flow(hass, pyscript_bypass_setup):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
 
-async def test_import_flow_update_entry(hass, pyscript_bypass_setup):
+async def test_import_flow_update_entry(hass):
     """Test import config flow updates existing entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data=PYSCRIPT_SCHEMA({})
@@ -91,7 +91,7 @@ async def test_import_flow_update_entry(hass, pyscript_bypass_setup):
     assert result["reason"] == "updated_entry"
 
 
-async def test_import_flow_no_update(hass, pyscript_bypass_setup):
+async def test_import_flow_no_update(hass):
     """Test import config flow doesn't update existing entry when data is same."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data=PYSCRIPT_SCHEMA({})

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,107 @@
+"""Tests for pyscript config flow."""
+import logging
+
+from custom_components.pyscript import PYSCRIPT_SCHEMA
+from custom_components.pyscript.const import CONF_ALLOW_ALL_IMPORTS, DOMAIN
+import pytest
+from pytest_homeassistant.async_mock import patch
+
+from homeassistant import data_entry_flow
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(name="pyscript_bypass_setup")
+def pyscript_bypass_setup_fixture():
+    """Mock component setup."""
+    with patch("custom_components.pyscript.async_setup_entry", return_value=True):
+        yield
+
+
+async def test_user_flow_minimum_fields(hass, pyscript_bypass_setup):
+    """Test user config flow with minimum fields."""
+    # test form shows
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": SOURCE_USER})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={})
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert CONF_ALLOW_ALL_IMPORTS in result["data"]
+    assert not result["data"][CONF_ALLOW_ALL_IMPORTS]
+
+
+async def test_user_flow_all_fields(hass, pyscript_bypass_setup,) -> None:
+    """Test user config flow with all fields."""
+    # test form shows
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": SOURCE_USER})
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_ALLOW_ALL_IMPORTS: True}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert CONF_ALLOW_ALL_IMPORTS in result["data"]
+    assert result["data"][CONF_ALLOW_ALL_IMPORTS]
+
+
+async def test_user_already_configured(hass, pyscript_bypass_setup,) -> None:
+    """Test service is already configured during user setup."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data={CONF_ALLOW_ALL_IMPORTS: True}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data={CONF_ALLOW_ALL_IMPORTS: True}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "single_instance_allowed"
+
+
+async def test_import_flow(hass, pyscript_bypass_setup):
+    """Test import config flow works."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=PYSCRIPT_SCHEMA({})
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+
+async def test_import_flow_update_entry(hass, pyscript_bypass_setup):
+    """Test import config flow updates existing entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=PYSCRIPT_SCHEMA({})
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_ALLOW_ALL_IMPORTS: True}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "updated_entry"
+
+
+async def test_import_flow_no_update(hass, pyscript_bypass_setup):
+    """Test import config flow doesn't update existing entry when data is same."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=PYSCRIPT_SCHEMA({})
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=PYSCRIPT_SCHEMA({})
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured_service"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -65,8 +65,8 @@ async def wait_until_done(notify_q):
     return await asyncio.wait_for(notify_q.get(), timeout=4)
 
 
-async def test_setup_fails_on_no_dir(hass, caplog):
-    """Test we fail setup when no dir found."""
+async def test_setup_makedirs_on_no_dir(hass, caplog):
+    """Test setup calls os.makedirs when no dir found."""
     integration = loader.Integration(
         hass,
         "custom_components.pyscript",
@@ -76,11 +76,11 @@ async def test_setup_fails_on_no_dir(hass, caplog):
 
     with patch("homeassistant.loader.async_get_integration", return_value=integration), patch(
         "custom_components.pyscript.os.path.isdir", return_value=False
-    ):
+    ), patch("custom_components.pyscript.os.makedirs") as makedirs_call:
         res = await async_setup_component(hass, "pyscript", {DOMAIN: {}})
 
-    assert not res
-    assert "Folder pyscript not found in configuration folder" in caplog.text
+    assert res
+    assert makedirs_call.called
 
 
 async def test_service_exists(hass, caplog):


### PR DESCRIPTION
This change makes it possible to setup pyscript from the UI so a restart is not required (but `configuration.yaml` is still supported so there is no breaking change). I also updated the code to create the `<config/path>/pyscript` folder if it doesn't exist - not sure if there was an intentional reason why you required the user to create the folder but it seemed like an easy improvement (and otherwise, the user would have to create the pyscript folder *before* setting the integration up in the UI).