### PR TITLE
Support reloading allow all imports through reload service and config entry options UI

### DIFF
--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -65,7 +65,7 @@ async def async_setup_entry(hass, config_entry):
         await hass.async_add_executor_job(os.makedirs, pyscript_folder)
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][CONF_ALLOW_ALL_IMPORTS] = config_entry.data.get(CONF_ALLOW_ALL_IMPORTS)
+    hass.data[DOMAIN] = config_entry
 
     State.set_pyscript_config(config_entry.data)
 

--- a/custom_components/pyscript/config_flow.py
+++ b/custom_components/pyscript/config_flow.py
@@ -21,11 +21,13 @@ class PyscriptOptionsConfigFlow(config_entries.OptionsFlow):
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize pyscript options flow."""
         self.config_entry = config_entry
+        self._show_form = False
 
     async def async_step_init(self, user_input: Dict[str, Any] = None) -> Dict[str, Any]:
         """Manage the pyscript options."""
         if self.config_entry.source == SOURCE_IMPORT:
-            return self.async_abort(reason="no_ui_configuration_allowed")
+            self._show_form = True
+            return await self.async_step_no_ui_configuration_allowed()
 
         if user_input is None:
             return self.async_show_form(
@@ -46,7 +48,26 @@ class PyscriptOptionsConfigFlow(config_entries.OptionsFlow):
             self.hass.config_entries.async_update_entry(entry=self.config_entry, data=updated_data)
             return self.async_create_entry(title="", data={})
 
-        return self.async_abort(reason="no_update")
+        self._show_form = True
+        return await self.async_step_no_update()
+
+    async def async_step_no_ui_configuration_allowed(
+        self, user_input: Dict[str, Any] = None
+    ) -> Dict[str, Any]:
+        """Tell user no UI configuration is allowed."""
+        if self._show_form:
+            self._show_form = False
+            return self.async_show_form(step_id="no_ui_configuration_allowed", data_schema=vol.Schema({}))
+
+        return self.async_create_entry(title="", data={})
+
+    async def async_step_no_update(self, user_input: Dict[str, Any] = None) -> Dict[str, Any]:
+        """Tell user no update to process."""
+        if self._show_form:
+            self._show_form = False
+            return self.async_show_form(step_id="no_update", data_schema=vol.Schema({}))
+
+        return self.async_create_entry(title="", data={})
 
 
 class PyscriptConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/pyscript/strings.json
+++ b/custom_components/pyscript/strings.json
@@ -22,11 +22,15 @@
         "data": {
           "allow_all_imports": "Allow All Imports?"
         }
+      },
+      "no_ui_configuration_allowed": {
+        "title": "No UI configuration allowed",
+        "description": "This entry was created via `configuration.yaml`, so all configuration parameters must be updated there. The [`pyscript.reload`](developer-tools/service) service will allow you to apply the changes you make to `configuration.yaml` without restarting your Home Assistant instance."
+      },
+      "no_update": {
+        "title": "No update needed",
+        "description": "There is nothing to update."
       }
-    },
-    "abort": {
-      "no_ui_configuration_allowed": "This entry was created via `configuration.yaml`, so all configuration parameters must be updated there. The [`pyscript.reload`](developer-tools/service) service will allow you to apply the changes you make to `configuration.yaml` without restarting your Home Assistant instance.",
-      "no_update": "There is nothing to update."
     }
   }
 }

--- a/custom_components/pyscript/strings.json
+++ b/custom_components/pyscript/strings.json
@@ -14,5 +14,19 @@
       "single_instance_allowed": "Already configured. Only a single configuration possible.",
       "updated_entry": "This entry has already been setup but the configuration has been updated."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Update pyscript configuration",
+        "data": {
+          "allow_all_imports": "Allow All Imports?"
+        }
+      }
+    },
+    "abort": {
+      "no_ui_configuration_allowed": "This entry was created via `configuration.yaml`, so all configuration parameters must be updated there. The [`pyscript.reload`](developer-tools/service) service will allow you to apply the changes you make to `configuration.yaml` without restarting your Home Assistant instance.",
+      "no_update": "There is nothing to update."
+    }
   }
 }

--- a/custom_components/pyscript/translations/en.json
+++ b/custom_components/pyscript/translations/en.json
@@ -22,11 +22,15 @@
         "data": {
           "allow_all_imports": "Allow All Imports?"
         }
+      },
+      "no_ui_configuration_allowed": {
+        "title": "No UI configuration allowed",
+        "description": "This entry was created via `configuration.yaml`, so all configuration parameters must be updated there. The [`pyscript.reload`](developer-tools/service) service will allow you to apply the changes you make to `configuration.yaml` without restarting your Home Assistant instance."
+      },
+      "no_update": {
+        "title": "No update needed",
+        "description": "There is nothing to update."
       }
-    },
-    "abort": {
-      "no_ui_configuration_allowed": "This entry was created via `configuration.yaml`, so all configuration parameters must be updated there. The [`pyscript.reload`](developer-tools/service) service will allow you to apply the changes you make to `configuration.yaml` without restarting your Home Assistant instance.",
-      "no_update": "There is nothing to update."
     }
   }
 }

--- a/custom_components/pyscript/translations/en.json
+++ b/custom_components/pyscript/translations/en.json
@@ -14,5 +14,19 @@
       "single_instance_allowed": "Already configured. Only a single configuration possible.",
       "updated_entry": "This entry has already been setup but the configuration has been updated."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Update pyscript configuration",
+        "data": {
+          "allow_all_imports": "Allow All Imports?"
+        }
+      }
+    },
+    "abort": {
+      "no_ui_configuration_allowed": "This entry was created via `configuration.yaml`, so all configuration parameters must be updated there. The [`pyscript.reload`](developer-tools/service) service will allow you to apply the changes you make to `configuration.yaml` without restarting your Home Assistant instance.",
+      "no_update": "There is nothing to update."
+    }
   }
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -187,8 +187,13 @@ async def test_options_flow_import(hass):
 
     result = await hass.config_entries.options.async_init(entry.entry_id, data=None)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "no_ui_configuration_allowed"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "no_ui_configuration_allowed"
+
+    result = await hass.config_entries.options.async_configure(result["flow_id"], user_input=None)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == ""
 
 
 async def test_options_flow_user_change(hass):
@@ -234,5 +239,10 @@ async def test_options_flow_user_no_change(hass):
         result["flow_id"], user_input={CONF_ALLOW_ALL_IMPORTS: True}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "no_update"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "no_update"
+
+    result = await hass.config_entries.options.async_configure(result["flow_id"], user_input=None)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == ""

--- a/tests/test_unit_eval.py
+++ b/tests/test_unit_eval.py
@@ -1,9 +1,11 @@
 """Unit tests for Python interpreter."""
 
+from custom_components.pyscript.const import CONF_ALLOW_ALL_IMPORTS, DOMAIN
 from custom_components.pyscript.eval import AstEval
 from custom_components.pyscript.function import Function
 from custom_components.pyscript.global_ctx import GlobalContext, GlobalContextMgr
 from custom_components.pyscript.state import State
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 evalTests = [
     ["1", 1],
@@ -882,6 +884,7 @@ async def run_one_test(test_data):
 
 async def test_eval(hass):
     """Test interpreter."""
+    hass.data[DOMAIN] = MockConfigEntry(domain=DOMAIN, data={CONF_ALLOW_ALL_IMPORTS: False})
     Function.init(hass)
     State.init(hass)
     State.register_functions()
@@ -1062,6 +1065,7 @@ async def run_one_test_exception(test_data):
 
 async def test_eval_exceptions(hass):
     """Test interpreter exceptions."""
+    hass.data[DOMAIN] = MockConfigEntry(domain=DOMAIN, data={CONF_ALLOW_ALL_IMPORTS: False})
     Function.init(hass)
     State.init(hass)
     State.register_functions()


### PR DESCRIPTION
As discussed in #39 , this change makes it possible to reload `allow_all_imports` via the reload service and also to configure it using the options menu for users who set up the entry through the UI (options will not work for users who do import, because when a user runs the reload service, and there is a mismatch between what's in the config and what was set in options, it would be impossible to know which one takes precedence. The config flow handles this gracefully and tells the user this if they attempt to access options for a config entry they defined in `configuration.yaml`).

I'm marking this as a draft because I discovered that my implementation won't work without https://github.com/home-assistant/core/pull/41875

I can change the implementation to avoid this, but it would be a less desirable user experience so I am hoping that PR gets accepted.