### PR TITLE
Persist pyscript.* states between home assistant restarts

### DIFF
--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -428,8 +428,9 @@ class EvalFunc:
                                 break
                         else:
                             continue
-                        for ok_type in arg_info["type"]:
-                            mesg += f", or {ok_type.__name__}"
+                        mesg += ", or " + ", or ".join(
+                            sorted([ok_type.__name__ for ok_type in arg_info["type"]])
+                        )
                 self.logger.error(
                     "%s defined in %s: decorator @%s argument %d should be a %s; ignoring decorator",
                     self.name,

--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -1307,7 +1307,7 @@ class AstEval:
             # a two-dot name for state.attr needs to exist
             #
             if num_dots == 1 or (num_dots == 2 and State.exist(arg.id)):
-                return State.get(arg.id)
+                return await State.get(arg.id)
             #
             # Couldn't find it, so return just the name wrapped in EvalName to
             # distinguish from a string variable value.  This is to support

--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -1168,7 +1168,7 @@ class AstEval:
             if not isinstance(var_name, str):
                 raise NotImplementedError(f"unknown lhs type {lhs} (got {var_name}) in assign")
             if var_name.find(".") >= 0:
-                State.set(var_name, val)
+                await State.set(var_name, val)
                 return
             if self.curr_func and var_name in self.curr_func.global_names:
                 self.global_sym_table[var_name] = val

--- a/custom_components/pyscript/state.py
+++ b/custom_components/pyscript/state.py
@@ -62,7 +62,6 @@ class State:
             if state_var_name not in cls.notify:
                 cls.notify[state_var_name] = {}
             cls.notify[state_var_name][queue] = var_names
-            await cls.register_persist(state_var_name)
 
     @classmethod
     def notify_del(cls, var_names, queue):
@@ -122,7 +121,6 @@ class State:
         _LOGGER.debug("setting %s = %s, attr = %s", var_name, value, new_attributes)
         cls.notify_var_last[var_name] = str(value)
 
-        await cls.register_persist(var_name)
         cls.hass.states.async_set(var_name, value, new_attributes)
 
     @classmethod
@@ -151,16 +149,6 @@ class State:
             await cls.set(var_name, current.state, **new_attributes)
 
     @classmethod
-    async def persist_prefix(cls, prefix):
-        """Ensures all pyscript domain state variable with prefix are persisted."""
-        if prefix.count(".") != 1 or not prefix.startswith("pyscript."):
-            raise NameError(f"invalid prefix {prefix} (should be 'pyscript.entity')")
-
-        for name in await cls.names("pyscript"):
-            if name.startswith(prefix):
-                await cls.register_persist(name)
-
-    @classmethod
     def exist(cls, var_name):
         """Check if a state variable value or attribute exists in hass."""
         parts = var_name.split(".")
@@ -176,7 +164,6 @@ class State:
         if len(parts) != 2 and len(parts) != 3:
             raise NameError(f"invalid name '{var_name}' (should be 'domain.entity')")
         value = cls.hass.states.get(f"{parts[0]}.{parts[1]}")
-        await cls.register_persist(var_name)
         if not value:
             raise NameError(f"name '{parts[0]}.{parts[1]}' is not defined")
         if len(parts) == 2:
@@ -191,7 +178,6 @@ class State:
         if var_name.count(".") != 1:
             raise NameError(f"invalid name {var_name} (should be 'domain.entity')")
         value = cls.hass.states.get(var_name)
-        await cls.register_persist(var_name)
         if not value:
             return None
         return value.attributes.copy()

--- a/custom_components/pyscript/state.py
+++ b/custom_components/pyscript/state.py
@@ -222,7 +222,6 @@ class State:
             "state.names": cls.names,
             "state.get_attr": cls.get_attr,
             "state.persist": cls.persist,
-            "state.persist_prefix": cls.persist_prefix,
             "pyscript.config": cls.pyscript_config,
         }
         Function.register(functions)

--- a/custom_components/pyscript/state.py
+++ b/custom_components/pyscript/state.py
@@ -144,6 +144,16 @@ class State:
             await cls.set(var_name, default_value)
 
     @classmethod
+    async def persist_prefix(cls, prefix):
+        """Ensures all pyscript domain state variable with prefix are persisted."""
+        if prefix.count(".") != 1 or not prefix.startswith("pyscript."):
+            raise NameError(f"invalid prefix {prefix} (should be 'pyscript.entity')")
+
+        for name in await cls.names("pyscript"):
+            if name.startswith(prefix):
+                await cls.register_persist(name)
+
+    @classmethod
     def exist(cls, var_name):
         """Check if a state variable value or attribute exists in hass."""
         parts = var_name.split(".")
@@ -219,6 +229,7 @@ class State:
             "state.names": cls.names,
             "state.get_attr": cls.get_attr,
             "state.persist": cls.persist,
+            "state.persist_prefix": cls.persist_prefix,
             "pyscript.config": cls.pyscript_config,
         }
         Function.register(functions)

--- a/custom_components/pyscript/trigger.py
+++ b/custom_components/pyscript/trigger.py
@@ -159,7 +159,7 @@ class TrigTime:
                 "trigger %s wait_until: watching vars %s", ast_ctx.name, state_trig_ident,
             )
             if len(state_trig_ident) > 0:
-                State.notify_add(state_trig_ident, notify_q)
+                await State.notify_add(state_trig_ident, notify_q)
         if event_trigger is not None:
             if isinstance(event_trigger, str):
                 event_trigger = [event_trigger]
@@ -595,7 +595,7 @@ class TrigInfo:
                 self.state_trig_ident.update(self.state_trig_ident_any)
                 _LOGGER.debug("trigger %s: watching vars %s", self.name, self.state_trig_ident)
                 if len(self.state_trig_ident) > 0:
-                    State.notify_add(self.state_trig_ident, self.notify_q)
+                    await State.notify_add(self.state_trig_ident, self.notify_q)
 
             if self.active_expr:
                 self.state_active_ident = await self.active_expr.get_names()

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -175,7 +175,7 @@ the prior value is also available to the expression as ``domain.name.old`` in ca
 condition the trigger on the prior value too.
 
 Multiple arguments are logically "or"ed together, so the trigger occurs if any of the expressions
-evaluate to ``True``. Any argument can alternatively be be a list or set of strings, and they are
+evaluate to ``True``. Any argument can alternatively be a list or set of strings, and they are
 treated the same as multiple arguments by "or"ing them together.
 
 All state variables in HASS have string values. So you’ll have to do comparisons against string
@@ -205,7 +205,7 @@ You can specify a state trigger on any change with a string that is just the sta
    @state_trigger("domain.light_level")
 
 The trigger can include arguments with any mixture of string expressions (that are evaluated
-when any of the underlying state variable change) and string state variable names (that trigger
+when any of the underlying state variables change) and string state variable names (that trigger
 whenever that variable changes).
 
 Note that if a state variable is set to the same value, HASS doesn’t generate a state change event,

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -551,12 +551,11 @@ variable has a numeric value, you might want to convert it to a numeric type (eg
 Persistent State
 ^^^^^^^^^^^^^^^^
 
-Two methods are provided to explicitly indicate that a particular entity_id should be persisted.
+This method is provided to indicate that a particular entity_id should be persisted. This is only effective for entitys in the `pyscript` domain.
 
 ``state.persist(entity_id, default_value=None)``
   Indicates that the entity named in `entity_id` should be persisted. Optionally, a default value can be provided.
-``state.persist_prefix(entity_prefix)``
-  Indicates that all entity_ids starting with the provided prefix should be persisted.
+
 
 
 Service Calls
@@ -1171,56 +1170,8 @@ Attributes can be included:
    pyscript.test.friendly_name = 'Test'
    pyscript.test.device_class = 'motion'
 
-In order to ensure that the state of a particular entity persists, you need to be certain that your Pyscript code "accesses" it in some way _every_ time Home Assistant is restarted. The following methods are considered to be accessing the persistent state.
+In order to ensure that the state of a particular entity persists, you need to request persistence explicitly. This must be done in a code location that will be certain to run at startup. Generally, this means outside of trigger functions.
 
-1) Use it in a `@state_trigger`:
-
-.. code:: python
-
-   @state_trigger('pyscript.test == "on"')
-   def my_function():
-     log.info('pyscript.test was set to "on"')
-
-
-2) Set a state
-
-.. code:: python
-
-   pyscript.test = "on"
-
-   state.set('pyscript.test', 'on')
-
-
-3) Read a state
-
-.. code:: python
-
-   if pyscript.test == "on":
-     log.info('pyscript.test is "on"')
-
-   test_value = state.get('pyscript.test')
-   log.info(f'The test value is {test_value}')
-
-4) Use the explicit persistence methods
-
-.. code:: python
-
-   state.persist('pyscript.test', default_value="on")
-
-   state.persist_prefix('pyscript.test_')
-
-Be aware that there are cases where it may seem the entity will be persisted, but, in actuality it will not. Consider the following example:
-
-.. code:: python
-
-   @state_trigger('binary_sensor.motion == "on"')
-   def turn_on_lights():
-     light.turn_on('light.overhead')
-     pyscript.last_light_on = "light.overhead"
-
-In this example, while the state is being set with `pyscript.last_light_on = "light.overhead"`, there is no guarantee that this particular `@state_trigger` will fire. If it doesn't fire, then the set action is never taken. If the set action doesn't happen before Home Assistant is restarted, then this entity will no longer persist.
-
-In order to ensure persistence in these cases, it is advised to use the explict syntax.
 
 .. code:: python
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -569,8 +569,8 @@ Persistent State
 
 This method is provided to indicate that a particular entity_id should be persisted. This is only effective for entitys in the `pyscript` domain.
 
-``state.persist(entity_id, default_value=None)``
-  Indicates that the entity named in `entity_id` should be persisted. Optionally, a default value can be provided.
+``state.persist(entity_id, default_value=None, default_attributes=None)``
+  Indicates that the entity named in `entity_id` should be persisted. Optionally, a default value and default attributes can be provided.
 
 
 


### PR DESCRIPTION
With this change any states set by pyscript in the pyscript domain
will be persisted when home assistant next reboots.

For example when a script runs `pyscript.abc = 'foo'` then this value
will be persisted.

Fixes #47