### PR TITLE
Add context for state_trigger and event_trigger

### DIFF
--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -187,6 +187,7 @@ async def async_setup_entry(hass, config_entry):
             "var_name": var_name,
             "value": new_val,
             "old_value": old_val,
+            "context": event.context,
         }
         await State.update(new_vars, func_args)
 

--- a/custom_components/pyscript/event.py
+++ b/custom_components/pyscript/event.py
@@ -39,6 +39,7 @@ class Event:
         func_args = {
             "trigger_type": "event",
             "event_type": event.event_type,
+            "context": event.context,
         }
         func_args.update(event.data)
         await cls.update(event.event_type, func_args)


### PR DESCRIPTION
This partially resolves #50.

Test with the following:

```python
@state_trigger(['input_boolean.test_1'])
def test_state_trigger(**data):
    log.info(data)


@event_trigger('PYSCRIPT_TEST')
def test_event_trigger(**data):
    log.info(data)
```

`context` should be visible in both cases of `data`.