### PR TITLE
event.fire and state.set send context if provided

### DIFF
--- a/custom_components/pyscript/function.py
+++ b/custom_components/pyscript/function.py
@@ -117,7 +117,12 @@ class Function:
     @classmethod
     async def event_fire(cls, event_type, **kwargs):
         """Implement event.fire()."""
-        cls.hass.bus.async_fire(event_type, kwargs)
+        if "context" in kwargs and isinstance(kwargs["context"], Context):
+            context = kwargs["context"]
+            del kwargs["context"]
+            cls.hass.bus.async_fire(event_type, kwargs, context=context)
+        else:
+            cls.hass.bus.async_fire(event_type, kwargs)
 
     @classmethod
     def task_unique_factory(cls, ctx):

--- a/custom_components/pyscript/state.py
+++ b/custom_components/pyscript/state.py
@@ -3,6 +3,7 @@
 import logging
 
 from homeassistant.helpers.restore_state import RestoreStateData
+from homeassistant.core import Context
 
 from .const import LOGGER_PATH
 from .function import Function
@@ -115,13 +116,19 @@ class State:
                 new_attributes = state_value.attributes
             else:
                 new_attributes = {}
+
+        context = None
+        if "context" in kwargs and isinstance(kwargs["context"], Context):
+            context = kwargs["context"]
+            del kwargs["context"]
+
         if kwargs:
             new_attributes = new_attributes.copy()
             new_attributes.update(kwargs)
         _LOGGER.debug("setting %s = %s, attr = %s", var_name, value, new_attributes)
         cls.notify_var_last[var_name] = str(value)
 
-        cls.hass.states.async_set(var_name, value, new_attributes)
+        cls.hass.states.async_set(var_name, value, new_attributes, context=context)
 
     @classmethod
     async def register_persist(cls, var_name):


### PR DESCRIPTION
Test with:

```python
from homeassistant.core import Context


@state_trigger(['input_boolean.test_1'])
def test_state_trigger(**data):
    log.info(data)
    new_context = Context(parent_id=data['context'].id)
    state.set('binary_sensor.test', 'on', context=new_context)

@state_trigger(['binary_sensor.test'])
def test_context_sent(**data):
    log.info(data)

@event_trigger('PYSCRIPT_TEST')
def test_event_trigger(**data):
    log.info(data)
    new_context = Context(parent_id=data['context'].id)
    event.fire('PYSCRIPT_TEST2', context=new_context)

@event_trigger('PYSCRIPT_TEST2')
def test_context_sent_event(**data):
    log.info(data)
```

data logged by `test_context_sent_event` and `test_context_sent` should show `parent_id` of the received context. 