### PR TITLE
allow context on short form service calls

### DIFF
--- a/custom_components/pyscript/function.py
+++ b/custom_components/pyscript/function.py
@@ -239,7 +239,12 @@ class Function:
             return None
 
         async def service_call(*args, **kwargs):
-            await cls.hass.services.async_call(domain, service, kwargs)
+            if "context" in kwargs and isinstance(kwargs["context"], Context):
+                context = kwargs["context"]
+                del kwargs["context"]
+                await cls.hass.services.async_call(domain, service, kwargs, context=context)
+            else:
+                await cls.hass.services.async_call(domain, service, kwargs)
 
         return service_call
 


### PR DESCRIPTION
allow short form service calls (i.e. `input_boolean.turn_on(entity_id='whatever')`) to send context