### PR TITLE
Logbook Functionality

### DIFF
--- a/custom_components/pyscript/function.py
+++ b/custom_components/pyscript/function.py
@@ -125,10 +125,8 @@ class Function:
         if "context" in kwargs and isinstance(kwargs["context"], Context):
             context = kwargs["context"]
             del kwargs["context"]
-        elif curr_task in cls.task2context:
-            context = cls.task2context[curr_task]
         else:
-            context = Context()
+            context = cls.task2context.get(curr_task, None)
 
         cls.hass.bus.async_fire(event_type, kwargs, context=context)
 
@@ -195,10 +193,8 @@ class Function:
         if "context" in kwargs and isinstance(kwargs["context"], Context):
             context = kwargs["context"]
             del kwargs["context"]
-        elif curr_task in cls.task2context:
-            context = cls.task2context[curr_task]
         else:
-            context = Context()
+            context = cls.task2context.get(curr_task, None)
 
         await cls.hass.services.async_call(domain, name, kwargs, context=context)
 
@@ -261,10 +257,8 @@ class Function:
             if "context" in kwargs and isinstance(kwargs["context"], Context):
                 context = kwargs["context"]
                 del kwargs["context"]
-            elif curr_task in cls.task2context:
-                context = cls.task2context[curr_task]
             else:
-                context = Context()
+                context = cls.task2context.get(curr_task, None)
 
             await cls.hass.services.async_call(domain, service, kwargs, context=context)
 

--- a/custom_components/pyscript/function.py
+++ b/custom_components/pyscript/function.py
@@ -239,7 +239,12 @@ class Function:
             return None
 
         async def service_call(*args, **kwargs):
-            await cls.hass.services.async_call(domain, service, kwargs)
+            if "context" in kwargs and isinstance(kwargs["context"], Context):
+                context = kwargs["context"]
+                del kwargs["context"]
+                await cls.hass.services.async_call(domain, service, kwargs, False, context)
+            else:
+                await cls.hass.services.async_call(domain, service, kwargs)
 
         return service_call
 

--- a/custom_components/pyscript/function.py
+++ b/custom_components/pyscript/function.py
@@ -134,6 +134,7 @@ class Function:
 
     @classmethod
     def store_hass_context(cls, hass_context):
+        """Store a context against the running task."""
         curr_task = asyncio.current_task()
         cls.task2context[curr_task] = hass_context
 

--- a/custom_components/pyscript/function.py
+++ b/custom_components/pyscript/function.py
@@ -27,6 +27,10 @@ class Function:
     unique_name2task = {}
 
     #
+    # Mappings of task id to hass contexts
+    task2context = {}
+
+    #
     # Set of tasks that are running
     #
     our_tasks = set()
@@ -117,12 +121,21 @@ class Function:
     @classmethod
     async def event_fire(cls, event_type, **kwargs):
         """Implement event.fire()."""
+        curr_task = asyncio.current_task()
         if "context" in kwargs and isinstance(kwargs["context"], Context):
             context = kwargs["context"]
             del kwargs["context"]
-            cls.hass.bus.async_fire(event_type, kwargs, context=context)
+        elif curr_task in cls.task2context:
+            context = cls.task2context[curr_task]
         else:
-            cls.hass.bus.async_fire(event_type, kwargs)
+            context = Context()
+
+        cls.hass.bus.async_fire(event_type, kwargs, context=context)
+
+    @classmethod
+    def store_hass_context(cls, hass_context):
+        curr_task = asyncio.current_task()
+        cls.task2context[curr_task] = hass_context
 
     @classmethod
     def task_unique_factory(cls, ctx):
@@ -177,12 +190,16 @@ class Function:
     @classmethod
     async def service_call(cls, domain, name, **kwargs):
         """Implement service.call()."""
+        curr_task = asyncio.current_task()
         if "context" in kwargs and isinstance(kwargs["context"], Context):
             context = kwargs["context"]
             del kwargs["context"]
-            await cls.hass.services.async_call(domain, name, kwargs, context=context)
+        elif curr_task in cls.task2context:
+            context = cls.task2context[curr_task]
         else:
-            await cls.hass.services.async_call(domain, name, kwargs)
+            context = Context()
+
+        await cls.hass.services.async_call(domain, name, kwargs, context=context)
 
     @classmethod
     async def service_completions(cls, root):
@@ -239,12 +256,16 @@ class Function:
             return None
 
         async def service_call(*args, **kwargs):
+            curr_task = asyncio.current_task()
             if "context" in kwargs and isinstance(kwargs["context"], Context):
                 context = kwargs["context"]
                 del kwargs["context"]
-                await cls.hass.services.async_call(domain, service, kwargs, False, context)
+            elif curr_task in cls.task2context:
+                context = cls.task2context[curr_task]
             else:
-                await cls.hass.services.async_call(domain, service, kwargs)
+                context = Context()
+
+            await cls.hass.services.async_call(domain, service, kwargs, context=context)
 
         return service_call
 
@@ -266,6 +287,8 @@ class Function:
             if task in cls.unique_task2name:
                 del cls.unique_name2task[cls.unique_task2name[task]]
                 del cls.unique_task2name[task]
+            if task in cls.task2context:
+                del cls.task2context[task]
             cls.our_tasks.discard(task)
 
     @classmethod

--- a/custom_components/pyscript/logbook.py
+++ b/custom_components/pyscript/logbook.py
@@ -1,0 +1,45 @@
+"""Describe logbook events."""
+from homeassistant.core import callback
+
+from .const import DOMAIN
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@callback
+def async_describe_events(hass, async_describe_event):  # type: ignore
+    """Describe logbook events."""
+
+    @callback
+    def async_describe_logbook_event(event):  # type: ignore
+        """Describe a logbook event."""
+        data = event.data
+        func_args = data.get("func_args", {})
+        ev_name = data.get("name", "unknown")
+        ev_entity_id = data.get("entity_id", "pyscript.unknown")
+
+        ev_trigger_type = func_args.get("trigger_type", "unknown")
+        if ev_trigger_type == "event":
+            ev_source = f"event {func_args.get('event_type', 'unknown event')}"
+        elif ev_trigger_type == "state":
+            ev_source = f"state change {func_args.get('var_name', 'unknown entity')} == {func_args.get('value', 'unknown value')}"
+        elif ev_trigger_type == "time":
+            ev_trigger_time = func_args.get("trigger_time", "unknown")
+            if ev_trigger_time is None:
+                ev_trigger_time = "startup"
+            ev_source = f"time {ev_trigger_time}"
+        else:
+            ev_source = ev_trigger_type
+
+        message = f"has been triggered by {ev_source}"
+
+        return {
+            "name": ev_name,
+            "message": message,
+            "source": ev_source,
+            "entity_id": ev_entity_id,
+        }
+
+    async_describe_event(DOMAIN, "pyscript_running", async_describe_logbook_event)

--- a/custom_components/pyscript/state.py
+++ b/custom_components/pyscript/state.py
@@ -122,10 +122,8 @@ class State:
         if "context" in kwargs and isinstance(kwargs["context"], Context):
             context = kwargs["context"]
             del kwargs["context"]
-        elif curr_task in Function.task2context:
-            context = Function.task2context[curr_task]
         else:
-            context = Context()
+            context = Function.task2context.get(curr_task, None)
 
         if kwargs:
             new_attributes = new_attributes.copy()

--- a/custom_components/pyscript/state.py
+++ b/custom_components/pyscript/state.py
@@ -1,5 +1,6 @@
 """Handles state variable access and change notification."""
 
+import asyncio
 import logging
 
 from homeassistant.helpers.restore_state import RestoreStateData
@@ -117,10 +118,14 @@ class State:
             else:
                 new_attributes = {}
 
-        context = None
+        curr_task = asyncio.current_task()
         if "context" in kwargs and isinstance(kwargs["context"], Context):
             context = kwargs["context"]
             del kwargs["context"]
+        elif curr_task in Function.task2context:
+            context = Function.task2context[curr_task]
+        else:
+            context = Context()
 
         if kwargs:
             new_attributes = new_attributes.copy()

--- a/custom_components/pyscript/trigger.py
+++ b/custom_components/pyscript/trigger.py
@@ -831,7 +831,7 @@ class TrigInfo:
                 if "context" in func_args and isinstance(func_args["context"], Context):
                     hass_context = Context(parent_id=func_args["context"].id)
                 else:
-                    hass_context = Context()
+                    hass_context = None
 
                 # Fire an event indicating that pyscript is running
                 # Note: the event must have an entity_id for logbook to work correctly.
@@ -851,7 +851,7 @@ class TrigInfo:
                 async def do_func_call(func, ast_ctx, task_unique, task_unique_func, hass_context, **kwargs):
                     # Store HASS Context for this Task
                     Function.store_hass_context(hass_context)
-                    
+
                     if task_unique and task_unique_func:
                         await task_unique_func(task_unique)
                     await func.call(ast_ctx, **kwargs)


### PR DESCRIPTION
There might be a better way to do this instead of using `Function` like I have. However, it works.

A few things to note.

* The event fired before the function runs can be named anything we want. I chose "pyscript_running" and then realized Home Assistant uses "automation_triggered". This can be renamed by changing it in both `trigger.py` and `logbook.py`.

* While I have confirmed that `state.set()` is sending the correct context to the best of my knowledge, it seems that states set in this manner don't show up in the log book at all. The state still "sets" as expected, but there is no logbook entry. Therefore, all of the "context" code can be removed from `state.set()` if desired.

* I've left the original context as part of the trigger function kwargs. This way, pyscript users can still look at `user_id` to determine who did something. Unfortunately, determining if **pyscript** did something would mean climbing the context tree, which is tedious.

* I've also left context as an optional kwarg to `service.call` and `event.fire`. If a users passes a context, it'll use that. If they don't and we have one from the `pyscript_running` event we fired, it'll use that. If they want to disable the logbook functionality for some reason, they can pass `context=Context()`.

* The logbook attributes actions to entity_ids. And entity ids can only have one "." between the domain and name. So I'm sending, essentially, `__name__`, with "." converted to "_". This means the entity_ids are a bit ugly (ex. `pyscript.file_myfile_myfunction`). This is set in `trigger.py` and can be changed to anything we want as long as it fits the rules for entity ids.

I've tested events, service_calls, time triggers, and state.set with this code:

```python
@state_trigger(["input_boolean.test_1"])
def test_state_trigger(**data):
    log.info("test_state_trigger")
    input_boolean.toggle(entity_id="input_boolean.test_2")
    state.set("binary_sensor.test", "on")


@event_trigger("PYSCRIPT_TEST")
def test_event_trigger(**data):
    log.info("test_event_trigger")
    input_boolean.toggle(entity_id="input_boolean.test_3")


@state_trigger(["binary_sensor.test"])
def report_binary_sensor(**data):
    log.info(f"binary_sensor trigger with {data}")


@time_trigger("startup")
def test_time_trigger(**data):
    task.sleep(3)
    log.info(f"test_time_trigger {data}")
    input_boolean.toggle(entity_id="input_boolean.test_4")
```

It results in this logbook:

![logbook](https://user-images.githubusercontent.com/4126703/97559509-86680c80-19ab-11eb-88cf-f3852a51d2ab.png)
