### PR TITLE
Refactor logic for processing requirements.txt so all I/O operations happen in a single function

### DIFF
--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -307,7 +307,9 @@ async def install_requirements(hass):
                 # Attempt to get version of package. Do nothing if it's found since
                 # we want to use the version that's already installed to be safe
                 requirement = pkg_resources.Requirement.parse(pkg)
-                requirement_installed_version = installed_version(requirement.project_name)
+                requirement_installed_version = await hass.async_add_executor_job(
+                    installed_version, requirement.project_name
+                )
 
                 if requirement_installed_version in requirement:
                     _LOGGER.debug("`%s` already found", requirement.project_name)

--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -272,25 +272,21 @@ async def unload_scripts(global_ctx_only=None, unload_all=False):
 
 
 @bind_hass
-def load_all_requirement_lines(hass, requirements_paths, requirements_file):
-    """Load all lines from requirements_file located in requirements_paths."""
-    all_requirements = {}
+def process_all_requirements(hass, requirements_paths, requirements_file):
+    """
+    Load all lines from requirements_file located in requirements_paths.
+
+    Returns files and a list of packages, if any, that need to be installed.
+    """
+    all_requirements_to_process = {}
     for root in requirements_paths:
         for requirements_path in glob.glob(os.path.join(hass.config.path(FOLDER), root, requirements_file)):
             with open(requirements_path, "r") as requirements_fp:
-                all_requirements[requirements_path] = requirements_fp.readlines()
+                all_requirements_to_process[requirements_path] = requirements_fp.readlines()
 
-    return all_requirements
-
-
-@bind_hass
-async def install_requirements(hass):
-    """Install missing requirements from requirements.txt."""
-    all_requirements = await hass.async_add_executor_job(
-        load_all_requirement_lines, hass, REQUIREMENTS_PATHS, REQUIREMENTS_FILE
-    )
-    requirements_to_install = []
-    for requirements_path, pkg_lines in all_requirements.items():
+    all_requirements_to_install = {}
+    for requirements_path, pkg_lines in all_requirements_to_process.items():
+        all_requirements_to_install[requirements_path] = []
         for pkg in pkg_lines:
             # Remove inline comments which are accepted by pip but not by Home
             # Assistant's installation method.
@@ -307,9 +303,7 @@ async def install_requirements(hass):
                 # Attempt to get version of package. Do nothing if it's found since
                 # we want to use the version that's already installed to be safe
                 requirement = pkg_resources.Requirement.parse(pkg)
-                requirement_installed_version = await hass.async_add_executor_job(
-                    installed_version, requirement.project_name
-                )
+                requirement_installed_version = installed_version(requirement.project_name)
 
                 if requirement_installed_version in requirement:
                     _LOGGER.debug("`%s` already found", requirement.project_name)
@@ -325,10 +319,22 @@ async def install_requirements(hass):
             except PackageNotFoundError:
                 # Since package wasn't found, add it to installation list
                 _LOGGER.debug("%s not found, adding it to package installation list", pkg)
-                requirements_to_install.append(pkg)
+                all_requirements_to_install[requirements_path].append(pkg)
             except ValueError:
                 # Not valid requirements line so it can be skipped
                 _LOGGER.debug("Ignoring `%s` because it is not a valid package", pkg)
+
+    return all_requirements_to_install
+
+
+@bind_hass
+async def install_requirements(hass):
+    """Install missing requirements from requirements.txt."""
+    all_requirements = await hass.async_add_executor_job(
+        process_all_requirements, hass, REQUIREMENTS_PATHS, REQUIREMENTS_FILE
+    )
+
+    for requirements_path, requirements_to_install in all_requirements.items():
         if requirements_to_install:
             _LOGGER.info(
                 "Installing the following packages from %s: %s",

--- a/tests/test_decorator_errors.py
+++ b/tests/test_decorator_errors.py
@@ -24,15 +24,8 @@ async def setup_script(hass, notify_q, now, source):
     ), patch(
         "homeassistant.config.load_yaml_config_file", return_value={}
     ), patch(
-        "custom_components.pyscript.load_all_requirement_lines",
-        return_value={
-            "/some/config/dir/pyscript/requirements.txt": [
-                "pytube==9.7.0\n",
-                "# another test comment\n",
-                "pykakasi==2.0.1 # test comment\n",
-                "\n",
-            ]
-        },
+        "custom_components.pyscript.process_all_requirements",
+        return_value={"/some/config/dir/pyscript/requirements.txt": ["pytube==2.0.1", "pykakasi==2.0.1"]},
     ):
         assert await async_setup_component(hass, "pyscript", {DOMAIN: {}})
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -111,15 +111,8 @@ async def setup_script(hass, notify_q, now, source):
     ), patch(
         "homeassistant.config.load_yaml_config_file", return_value={DOMAIN: {CONF_ALLOW_ALL_IMPORTS: True}}
     ), patch(
-        "custom_components.pyscript.load_all_requirement_lines",
-        return_value={
-            "/some/config/dir/pyscript/requirements.txt": [
-                "pytube==9.7.0\n",
-                "# another test comment\n",
-                "pykakasi==2.0.1 # test comment\n",
-                "\n",
-            ]
-        },
+        "custom_components.pyscript.process_all_requirements",
+        return_value={"/some/config/dir/pyscript/requirements.txt": ["pytube==2.0.1", "pykakasi==2.0.1"]},
     ):
         assert await async_setup_component(hass, "pyscript", {DOMAIN: {CONF_ALLOW_ALL_IMPORTS: True}})
 

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -118,15 +118,8 @@ async def setup_script(hass, now, source, no_connect=False):
     ), patch(
         "homeassistant.config.load_yaml_config_file", return_value={}
     ), patch(
-        "custom_components.pyscript.load_all_requirement_lines",
-        return_value={
-            "/some/config/dir/pyscript/requirements.txt": [
-                "pytube==9.7.0\n",
-                "# another test comment\n",
-                "pykakasi==2.0.1 # test comment\n",
-                "\n",
-            ]
-        },
+        "custom_components.pyscript.process_all_requirements",
+        return_value={"/some/config/dir/pyscript/requirements.txt": ["pytube==2.0.1", "pykakasi==2.0.1"]},
     ):
         assert await async_setup_component(hass, "pyscript", {DOMAIN: {}})
 

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -24,15 +24,8 @@ async def setup_script(hass, notify_q, now, source):
     ), patch(
         "homeassistant.config.load_yaml_config_file", return_value={}
     ), patch(
-        "custom_components.pyscript.load_all_requirement_lines",
-        return_value={
-            "/some/config/dir/pyscript/requirements.txt": [
-                "pytube==9.7.0\n",
-                "# another test comment\n",
-                "pykakasi==2.0.1 # test comment\n",
-                "\n",
-            ]
-        },
+        "custom_components.pyscript.process_all_requirements",
+        return_value={"/some/config/dir/pyscript/requirements.txt": ["pytube==2.0.1", "pykakasi==2.0.1"]},
     ):
         assert await async_setup_component(hass, "pyscript", {DOMAIN: {}})
 


### PR DESCRIPTION
`installed_version` also does IO from #68, this moves it to an executor job. Thanks @bdraco for catching this!