### PR TITLE
WIP: detect old attribute values

### DIFF
--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -232,7 +232,7 @@ async def async_setup_entry(hass, config_entry):
 
         for attribute in event.data["new_state"].attributes:
             new_val = event.data["new_state"].attributes[attribute]
-            if "old_state" in event.data and attribute in event.data["old_state"].attributes:
+            if "old_state" in event.data and event.data['old_state'] is not None and attribute in event.data["old_state"].attributes:
                 old_val = event.data["old_state"].attributes[attribute]
             else:
                 old_val = None

--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -211,7 +211,7 @@ async def async_setup_entry(hass, config_entry):
             new_val = event.data["new_state"].state
         old_val = event.data["old_state"].state if event.data["old_state"] else None
 
-        if old_val != new_val:
+        if old_val == new_val:
             val_change = False
         else:
             val_change = True
@@ -237,7 +237,7 @@ async def async_setup_entry(hass, config_entry):
             else:
                 old_val = None
 
-            if old_val != new_val:
+            if old_val == new_val:
                 val_change = False
             else:
                 val_change = True

--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -455,7 +455,7 @@ class EvalFunc:
         kwarg_check = {
             "task_unique": {"kill_me"},
             "time_active": {"hold_off"},
-            "state_trigger": {"state_hold", "state_check_now"},
+            "state_trigger": {"state_hold", "state_check_now", "only_on_change"},
         }
         for dec_name in trig_args:
             if dec_name not in kwarg_check and "kwargs" in trig_args[dec_name]:

--- a/custom_components/pyscript/state.py
+++ b/custom_components/pyscript/state.py
@@ -77,9 +77,13 @@ class State:
 
         for var_name in var_names if isinstance(var_names, set) else {var_names}:
             parts = var_name.split(".")
-            if len(parts) != 2 and len(parts) != 3:
+            if len(parts) == 2:
+                state_var_name = f"{parts[0]}.{parts[1]}"
+            elif len(parts) == 3:
+                state_var_name = f"{parts[0]}.{parts[1]}.{parts[2]}"
+            else:
                 continue
-            state_var_name = f"{parts[0]}.{parts[1]}"
+
             if state_var_name not in cls.notify:
                 cls.notify[state_var_name] = {}
             cls.notify[state_var_name][queue] = var_names

--- a/custom_components/pyscript/trigger.py
+++ b/custom_components/pyscript/trigger.py
@@ -538,6 +538,7 @@ class TrigInfo:
         self.state_trigger_kwargs = trig_cfg.get("state_trigger", {}).get("kwargs", {})
         self.state_hold_dur = self.state_trigger_kwargs.get("state_hold", None)
         self.state_check_now = self.state_trigger_kwargs.get("state_check_now", False)
+        self.only_on_change = self.state_trigger_kwargs.get("only_on_change", True)
         self.time_trigger = trig_cfg.get("time_trigger", {}).get("args", None)
         self.event_trigger = trig_cfg.get("event_trigger", {}).get("args", None)
         self.state_active = trig_cfg.get("state_active", {}).get("args", None)
@@ -784,6 +785,12 @@ class TrigInfo:
 
                 else:
                     func_args = notify_info
+
+                #
+                # check if our value changed and if we want to trigger on non changes
+                #
+                if self.only_on_change and "change" in func_args and not func_args['change']:
+                    continue
 
                 #
                 # now check the state and time active expressions

--- a/custom_components/pyscript/trigger.py
+++ b/custom_components/pyscript/trigger.py
@@ -22,7 +22,7 @@ from .state import State
 _LOGGER = logging.getLogger(LOGGER_PATH + ".trigger")
 
 
-STATE_RE = re.compile(r"[a-zA-Z]\w*\.[a-zA-Z]\w*$")
+STATE_RE = re.compile(r"[a-zA-Z]\w*\.[a-zA-Z]\w*(\.[a-zA-Z]\w*)?$")
 
 
 def dt_now():


### PR DESCRIPTION
This addresses #73 .

This may not be correct, but limited testing shows it works for me.

Old attribute values are available to state trigger as `binary_sensor.test.old.attribute_name`.

I've also added `change` to `func_args` to indicate that a change was detected. 

@state_trigger takes kwarg `only_on_change` (default: True) 

I will continue to update this PR as I test.

