### PR TITLE
WIP: Alternate implementation to only trigger on changes

### DIFF
--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -217,9 +217,16 @@ async def async_setup_entry(hass, config_entry):
             "value": new_val,
             "old_value": old_val,
             "context": event.context,
-            "old_state": event.data.get('old_state'),
-            "new_state": event.data.get('new_state'),
         }
+
+        if new_val is not None:
+            for attribute in event.data["new_state"].attributes:
+                new_vars[f"{var_name}.{attribute}"] = event.data["new_state"].attributes[attribute]
+
+        if old_val is not None:
+            for attribute in event.data["old_state"].attributes:
+                new_vars[f"{var_name}.{attribute}.old"] = event.data["old_state"].attributes[attribute]
+
         await State.update(new_vars, func_args)
 
     async def hass_started(event):

--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -217,6 +217,8 @@ async def async_setup_entry(hass, config_entry):
             "value": new_val,
             "old_value": old_val,
             "context": event.context,
+            "old_state": event.data.get('old_state'),
+            "new_state": event.data.get('new_state'),
         }
         await State.update(new_vars, func_args)
 

--- a/custom_components/pyscript/state.py
+++ b/custom_components/pyscript/state.py
@@ -115,12 +115,12 @@ class State:
     @classmethod
     def notify_var_get(cls, var_names, new_vars):
         """Return the most recent value of a state variable change."""
-        notify_vars = {}
+        notify_vars = new_vars
         for var_name in var_names if var_names is not None else []:
             if var_name in cls.notify_var_last:
                 notify_vars[var_name] = cls.notify_var_last[var_name]
-            elif var_name in new_vars:
-                notify_vars[var_name] = new_vars[var_name]
+            # elif var_name in new_vars:
+            #     notify_vars[var_name] = new_vars[var_name]
             elif 1 <= var_name.count(".") <= 2 and not cls.exist(var_name):
                 notify_vars[var_name] = None
         return notify_vars

--- a/custom_components/pyscript/trigger.py
+++ b/custom_components/pyscript/trigger.py
@@ -816,30 +816,14 @@ class TrigInfo:
                 #
                 # for state notify, check that changes occurred in state_trig_ident variables
                 #
-                if notify_type == 'state' and func_args['old_state'] is not None:
+                if notify_type == 'state':
                     trig_ident_changed = False
-                    changes = {}
-                    if func_args['old_state'].state != func_args['new_state'].state:
-                        changes[func_args['var_name']] = {
-                            "old": func_args['old_state'].state,
-                            "new": func_args['new_state'].state,
-                        }
-                        if func_args['var_name'] in self.state_trig_ident:
+                    for var in self.state_trig_ident:
+                        if new_vars.get(var) != new_vars.get(f"{var}.old"):
                             trig_ident_changed = True
-                    
-                    for attribute in func_args['new_state'].attributes:
-                        if func_args['new_state'].attributes[attribute] != func_args['old_state'].attributes[attribute]:
-                            changes[f"{func_args['var_name']}.{attribute}"] = {
-                                "old": func_args['old_state'].attributes[attribute],
-                                "new": func_args['new_state'].attributes[attribute],
-                            }
-                            if f"{func_args['var_name']}.{attribute}" in self.state_trig_ident:
-                                trig_ident_changed = True
-
+  
                     if not trig_ident_changed:
                         continue
-
-                    func_args['changes'] = changes
 
                 #
                 # check for @task_unique with kill_me=True

--- a/custom_components/pyscript/trigger.py
+++ b/custom_components/pyscript/trigger.py
@@ -812,6 +812,35 @@ class TrigInfo:
                 if self.task_unique is not None:
                     task_unique_func = Function.task_unique_factory(action_ast_ctx)
 
+
+                #
+                # for state notify, check that changes occurred in state_trig_ident variables
+                #
+                if notify_type == 'state' and func_args['old_state'] is not None:
+                    trig_ident_changed = False
+                    changes = {}
+                    if func_args['old_state'].state != func_args['new_state'].state:
+                        changes[func_args['var_name']] = {
+                            "old": func_args['old_state'].state,
+                            "new": func_args['new_state'].state,
+                        }
+                        if func_args['var_name'] in self.state_trig_ident:
+                            trig_ident_changed = True
+                    
+                    for attribute in func_args['new_state'].attributes:
+                        if func_args['new_state'].attributes[attribute] != func_args['old_state'].attributes[attribute]:
+                            changes[f"{func_args['var_name']}.{attribute}"] = {
+                                "old": func_args['old_state'].attributes[attribute],
+                                "new": func_args['new_state'].attributes[attribute],
+                            }
+                            if f"{func_args['var_name']}.{attribute}" in self.state_trig_ident:
+                                trig_ident_changed = True
+
+                    if not trig_ident_changed:
+                        continue
+
+                    func_args['changes'] = changes
+
                 #
                 # check for @task_unique with kill_me=True
                 #

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -734,7 +734,7 @@ def func_startup_sync2(trigger_type=None, var_name=None):
         res = literal_eval(await wait_until_done(notify_q))
         results[res[0]] = res
 
-    assert results == [[0, "state", 'pyscript.fstartup2'], [1, "state", 'pyscript.fstartup0']]
+    assert results == [[0, "state", None], [1, "state", None]]
 
     for _ in range(2):
         hass.states.async_set("pyscript.fstartup2", 10)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -734,7 +734,7 @@ def func_startup_sync2(trigger_type=None, var_name=None):
         res = literal_eval(await wait_until_done(notify_q))
         results[res[0]] = res
 
-    assert results == [[0, "state", None], [1, "state", None]]
+    assert results == [[0, "state", 'pyscript.fstartup2'], [1, "state", 'pyscript.fstartup0']]
 
     for _ in range(2):
         hass.states.async_set("pyscript.fstartup2", 10)


### PR DESCRIPTION
This is an alternate method of detecting changes to PR #76.

It provides `changes`, `old_state`, and `new_state` to `func_args`. 

It uses `state_trig_ident` to determine what the trigger cares about and only fires the function if one of these has changed.

It only fires once per state_changed event, since `State.update()` is only called once per state_changed event.

It does NOT fire if domain.entity.attribute has changed when only domain.entity is included in state_trigger. 

This PR could be extended to provide `only_on_change=False` kwarg functionality like #76 did.

This PR could be extended to provide `any_attribute_change=True` kwarg to allow any attribute change to fire the function.

This PR could also be extended to provide domain.entity.old.attribute pseudo-variables for checking in state_trigger. 