### PR TITLE
await in deprecated get_attr

### DIFF
--- a/custom_components/pyscript/state.py
+++ b/custom_components/pyscript/state.py
@@ -326,7 +326,7 @@ class State:
     async def get_attr(cls, var_name):
         """Return a dict of attributes for a state variable - deprecated."""
         _LOGGER.warning("state.get_attr() is deprecated: use state.getattr() instead")
-        return cls.getattr(var_name)
+        return await cls.getattr(var_name)
 
     @classmethod
     def completions(cls, root):


### PR DESCRIPTION
This PR will prevent the error:

`TypeError: argument of type 'coroutine' is not iterable`

In the following code:

```
@time_trigger('startup')
def test():
    a = state.get_attr('sun.sun')

    for attrib in a:
        log.info(attrib)
```