### PR TITLE
add @mqtt_trigger

### DIFF
--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -32,6 +32,7 @@ from .const import (
 )
 from .eval import AstEval
 from .event import Event
+from .mqtt import Mqtt
 from .function import Function
 from .global_ctx import GlobalContext, GlobalContextMgr
 from .jupyter_kernel import Kernel
@@ -118,6 +119,7 @@ async def async_setup_entry(hass, config_entry):
 
     Function.init(hass)
     Event.init(hass)
+    Mqtt.init(hass)
     TrigTime.init(hass)
     State.init(hass)
     State.register_functions()

--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -278,11 +278,13 @@ class EvalFunc:
             "time_trigger",
             "state_trigger",
             "event_trigger",
+            "mqtt_trigger",
         }
         trig_decorators = {
             "time_trigger",
             "state_trigger",
             "event_trigger",
+            "mqtt_trigger",
             "state_active",
             "time_active",
             "task_unique",
@@ -393,6 +395,7 @@ class EvalFunc:
         #
         arg_check = {
             "event_trigger": {"arg_cnt": {1, 2}},
+            "mqtt_trigger": {"arg_cnt": {1, 2}},
             "state_active": {"arg_cnt": {1}},
             "state_trigger": {"arg_cnt": {"*"}, "type": {list, set}},
             "task_unique": {"arg_cnt": {1}},

--- a/custom_components/pyscript/mqtt.py
+++ b/custom_components/pyscript/mqtt.py
@@ -36,7 +36,8 @@ class Mqtt:
 
     @classmethod
     def mqtt_message_handler_maker(cls, subscribed_topic):
-
+        """closure for mqtt_message_handler"""
+        
         async def mqtt_message_handler(mqttmsg):
             """Listen for MQTT messages."""
             func_args = {

--- a/custom_components/pyscript/mqtt.py
+++ b/custom_components/pyscript/mqtt.py
@@ -1,4 +1,4 @@
-"""Handles event firing and notification."""
+"""Handles mqtt messages and notification."""
 
 import logging
 import json
@@ -19,7 +19,7 @@ class Mqtt:
     hass = None
 
     #
-    # notify message queues by event type
+    # notify message queues by mqtt message topic
     #
     notify = {}
     notify_remove = {}
@@ -53,7 +53,7 @@ class Mqtt:
 
     @classmethod
     async def notify_add(cls, topic, queue):
-        """Register to notify for mqtt message of given topic to be sent to queue."""
+        """Register to notify for mqtt messages of given topic to be sent to queue."""
 
         if topic not in cls.notify:
             cls.notify[topic] = set()
@@ -65,7 +65,7 @@ class Mqtt:
 
     @classmethod
     def notify_del(cls, topic, queue):
-        """Unregister to notify for events of given type for given queue."""
+        """Unregister to notify for mqtt messages of given topic for given queue."""
 
         if topic not in cls.notify or queue not in cls.notify[topic]:
             return
@@ -78,7 +78,7 @@ class Mqtt:
 
     @classmethod
     async def update(cls, topic, func_args):
-        """Deliver all notifications for an event of the given type."""
+        """Deliver all notifications for an mqtt message on the given topic."""
 
         _LOGGER.debug("mqtt.update(%s, %s, %s)", topic, vars, func_args)
         if topic in cls.notify:

--- a/custom_components/pyscript/mqtt.py
+++ b/custom_components/pyscript/mqtt.py
@@ -48,7 +48,7 @@ class Mqtt:
             }
 
             try:
-                func_args["payload_json"] = json.loads(mqttmsg.payload)
+                func_args["payload_obj"] = json.loads(mqttmsg.payload)
             except ValueError:
                 pass
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -569,6 +569,33 @@ see that the ``EVENT_CALL_SERVICE`` event has parameters ``domain`` set to ``lig
 This `wiki page <https://github.com/custom-components/pyscript/wiki/Event-based-triggers>`__ gives
 more examples of built-in and user events and how to create triggers for them.
 
+@mqtt_trigger
+^^^^^^^^^^^^^
+
+.. code:: python
+
+    @mqtt_trigger(topic, str_expr=None)
+
+``@mqtt_trigger`` subscribes to the given MQTT ``topic`` and triggers whenever a message is received
+on that topic. An optional ``str_expr`` can be used to match the MQTT message data, and the trigger
+will only occur if that expression evaluates to ``True`` or non-zero. This expression has available
+these four variables:
+
+- ``trigger_type`` is set to “mqtt”
+- ``topic`` is set to the topic the message was received on
+- ``payload`` is set to the string payload of the message
+- ``payload_json`` if the payload was valid JSON, this will be set to the native python object
+  representing that payload.
+
+When the ``@mqtt_trigger`` occurs, those same variables are passed as keyword arguments to the
+function in case it needs them.
+
+Wildcards in topics are supported. The ``topic`` variables will be set to the full expanded topic
+the message arrived on.
+
+NOTE: The `MQTT Integration in Home Assistant <https://www.home-assistant.io/integrations/mqtt/>`__
+must be set up to use ``@mqtt_trigger``. 
+
 @task_unique
 ^^^^^^^^^^^^
 
@@ -859,6 +886,9 @@ It takes the following keyword arguments (all are optional):
 - ``event_trigger=None`` can be set to a string or list of two strings, just like
   ``@event_trigger``. The first string is the name of the event, and the second string
   (when the setting is a two-element list) is an expression based on the event parameters.
+- ``mqtt_trigger=None`` can be set to a string or list of two strings, just like
+  ``@mqtt_trigger``. The first string is the MQTT topic, and the second string
+  (when the setting is a two-element list) is an expression based on the message variables.
 - ``timeout=None`` an overall timeout in seconds, which can be floating point.
 - ``state_check_now=True`` if set, ``task.wait_until()`` checks any ``state_trigger``
   immediately to see if it is already ``True``, and will return immediately if so. If

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -584,7 +584,7 @@ these four variables:
 - ``trigger_type`` is set to “mqtt”
 - ``topic`` is set to the topic the message was received on
 - ``payload`` is set to the string payload of the message
-- ``payload_json`` if the payload was valid JSON, this will be set to the native python object
+- ``payload_obj`` if the payload was valid JSON, this will be set to the native python object
   representing that payload.
 
 When the ``@mqtt_trigger`` occurs, those same variables are passed as keyword arguments to the

--- a/tests/test_decorator_errors.py
+++ b/tests/test_decorator_errors.py
@@ -179,7 +179,7 @@ def func_wrapup():
     )
     assert "SyntaxError: invalid syntax (file.hello.func3 @state_active(), line 1)" in caplog.text
     assert (
-        "func4 defined in file.hello: needs at least one trigger decorator (ie: event_trigger, state_trigger, time_trigger)"
+        "func4 defined in file.hello: needs at least one trigger decorator (ie: event_trigger, mqtt_trigger, state_trigger, time_trigger)"
         in caplog.text
     )
     assert (


### PR DESCRIPTION
This is a quick first attempt. The simplest of test scripts seems to work:

```python
@time_trigger('startup')
def mqtt_counter():
    task.unique('mqtt_counter')
    cnt = 0
    while True:
        cnt = cnt + 1
        log.info(cnt)
        mqtt.publish(topic='pyscript/test', payload=cnt)
        mqtt.publish(topic='pyscript/testx10', payload=(cnt * 10))
        task.sleep(1)

@mqtt_trigger('pyscript/test')
def mqtt_recv(**data):
    log.info(f'got one {data}')

@mqtt_trigger('pyscript/test', 'topic == "notthis"')
def mqtt_never(**data):
    log.info(f'this should never happen {data}')

@mqtt_trigger('pyscript/test', 'int(payload) % 2 == 0')
def mqtt_even(**data):
    log.info(f'EVEN {data}')

@mqtt_trigger('pyscript/#')
def mqtt_wildcard(**data):
    log.info(f'got one from wildcard {data}')

@mqtt_trigger('pyscript/test', 'payload == "5"')
def mqtt_5_then_10():
    log.info('got 5, waiting for 10')
    task.wait_until(mqtt_trigger=['pyscript/test', 'payload == "10"'])
    log.info('got 10')
```

Tests are needed. Though... I'm not sure how to write tests without an mqtt server to test against?

Docs are needed.


Feel free to make edits directly in my repo even if you are unable to test them.

Will fix #98 .