### PR TITLE
entities platforms (sensor, binary_sensor, switch)

### DIFF
--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -64,6 +64,7 @@ PYSCRIPT_SCHEMA = vol.Schema(
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: PYSCRIPT_SCHEMA}, extra=vol.ALLOW_EXTRA)
 
+PLATFORMS = ["sensor"]
 
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Component setup, run import config flow for each entry in config."""
@@ -354,6 +355,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     hass.data[DOMAIN][UNSUB_LISTENERS].append(hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, hass_stop))
 
     await watchdog_start(hass, pyscript_folder, reload_scripts_handler)
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(config_entry, component)
+        )
 
     return True
 

--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -65,7 +65,7 @@ PYSCRIPT_SCHEMA = vol.Schema(
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: PYSCRIPT_SCHEMA}, extra=vol.ALLOW_EXTRA)
 
-PLATFORMS = ["sensor", "binary_sensor"]
+PLATFORMS = ["sensor", "binary_sensor", "switch"]
 
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Component setup, run import config flow for each entry in config."""

--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -65,7 +65,7 @@ PYSCRIPT_SCHEMA = vol.Schema(
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: PYSCRIPT_SCHEMA}, extra=vol.ALLOW_EXTRA)
 
-PLATFORMS = ["sensor"]
+PLATFORMS = ["sensor", "binary_sensor"]
 
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Component setup, run import config flow for each entry in config."""

--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -51,6 +51,7 @@ from .mqtt import Mqtt
 from .requirements import install_requirements
 from .state import State, StateVal
 from .trigger import TrigTime
+from .entity_manager import EntityManager
 
 _LOGGER = logging.getLogger(LOGGER_PATH)
 
@@ -241,6 +242,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     State.init(hass)
     State.register_functions()
     GlobalContextMgr.init()
+    EntityManager.init(hass)
 
     pyscript_folder = hass.config.path(FOLDER)
     if not await hass.async_add_executor_job(os.path.isdir, pyscript_folder):

--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -244,6 +244,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     GlobalContextMgr.init()
     EntityManager.init(hass)
 
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(config_entry, component)
+        )
+
     pyscript_folder = hass.config.path(FOLDER)
     if not await hass.async_add_executor_job(os.path.isdir, pyscript_folder):
         _LOGGER.debug("Folder %s not found in configuration folder, creating it", FOLDER)
@@ -357,11 +362,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     hass.data[DOMAIN][UNSUB_LISTENERS].append(hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, hass_stop))
 
     await watchdog_start(hass, pyscript_folder, reload_scripts_handler)
-
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(config_entry, component)
-        )
 
     return True
 

--- a/custom_components/pyscript/binary_sensor.py
+++ b/custom_components/pyscript/binary_sensor.py
@@ -1,0 +1,30 @@
+from .const import DOMAIN
+from .entity_manager import EntityManager, PyscriptEntity
+
+PLATFORM = 'binary_sensor'
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    EntityManager.register_platform(PLATFORM, async_add_entities, PyscriptBinarySensor)
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    return await async_setup_platform(
+        hass, config_entry.data, async_add_entities, discovery_info=None
+    )
+
+
+class PyscriptBinarySensor(PyscriptEntity):
+    platform = PLATFORM
+
+    def set_state(self, state):
+        if state is True:
+            state = "on"
+
+        if state is False:
+            state = "off"
+
+        state = state.lower()
+
+        if state not in ('on', 'off'):
+            raise ValueError('BinarySensor state must be "on" or "off"')
+            
+        self._state = state

--- a/custom_components/pyscript/binary_sensor.py
+++ b/custom_components/pyscript/binary_sensor.py
@@ -1,5 +1,6 @@
 """Pyscript Binary Sensor Entity"""
 from .entity_manager import EntityManager, PyscriptEntity
+from homeassistant.components.binary_sensor import BinarySensorEntity
 
 PLATFORM = "binary_sensor"
 
@@ -14,7 +15,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     return await async_setup_platform(hass, config_entry.data, async_add_entities, discovery_info=None)
 
 
-class PyscriptBinarySensor(PyscriptEntity):
+class PyscriptBinarySensor(PyscriptEntity, BinarySensorEntity):
     """A Pyscript Binary Sensor Entity"""
     platform = PLATFORM
 
@@ -22,10 +23,24 @@ class PyscriptBinarySensor(PyscriptEntity):
         super().__init__(*args, **kwargs)
         self._device_class = None
 
+
+    # USED BY HOME ASSISTANT
+    ##############################
+
+    @property
+    def is_on(self):
+        """Return true if binary sensor is on"""
+        if self._state == 'on':
+            return True
+        return False
+
     @property
     def device_class(self):
         """Return the device class of the sensor."""
         return self._device_class
+
+    # OVERRIDDEN FROM PyscriptEntity
+    ################################ 
 
     def set_state(self, state):
         """Handle State Validation"""
@@ -42,7 +57,7 @@ class PyscriptBinarySensor(PyscriptEntity):
 
         super().set_state(state)
 
-    # TO BE USED IN PYSCRIPT
+    # USED IN PYSCRIPT
     ######################################
 
     async def set_device_class(self, device_class):

--- a/custom_components/pyscript/binary_sensor.py
+++ b/custom_components/pyscript/binary_sensor.py
@@ -15,6 +15,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class PyscriptBinarySensor(PyscriptEntity):
     platform = PLATFORM
 
+    def init(self):
+        self._device_class = None
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return self._device_class
+
+    # TO BE USED IN PYSCRIPT
+    ######################################        
+
     def set_state(self, state):
         if state is True:
             state = "on"
@@ -26,5 +37,9 @@ class PyscriptBinarySensor(PyscriptEntity):
 
         if state not in ('on', 'off'):
             raise ValueError('BinarySensor state must be "on" or "off"')
-            
+
         self._state = state
+
+    async def set_device_class(self, device_class):
+        self._device_class = device_class
+        await self.async_update()

--- a/custom_components/pyscript/binary_sensor.py
+++ b/custom_components/pyscript/binary_sensor.py
@@ -27,9 +27,6 @@ class PyscriptBinarySensor(PyscriptEntity):
         """Return the device class of the sensor."""
         return self._device_class
 
-    # TO BE USED IN PYSCRIPT
-    ######################################
-
     def set_state(self, state):
         """Handle State Validation"""
         if state is True:
@@ -44,6 +41,9 @@ class PyscriptBinarySensor(PyscriptEntity):
             raise ValueError('BinarySensor state must be "on" or "off"')
 
         super().set_state(state)
+
+    # TO BE USED IN PYSCRIPT
+    ######################################
 
     async def set_device_class(self, device_class):
         """Set Device Class of Entity"""

--- a/custom_components/pyscript/binary_sensor.py
+++ b/custom_components/pyscript/binary_sensor.py
@@ -1,21 +1,25 @@
-from .const import DOMAIN
+"""Pyscript Binary Sensor Entity"""
 from .entity_manager import EntityManager, PyscriptEntity
 
-PLATFORM = 'binary_sensor'
+PLATFORM = "binary_sensor"
+
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Initialize Pyscript Binary Sensor Platform"""
     EntityManager.register_platform(PLATFORM, async_add_entities, PyscriptBinarySensor)
 
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    return await async_setup_platform(
-        hass, config_entry.data, async_add_entities, discovery_info=None
-    )
+    """Initialize Pyscript Binary Sensor Config"""
+    return await async_setup_platform(hass, config_entry.data, async_add_entities, discovery_info=None)
 
 
 class PyscriptBinarySensor(PyscriptEntity):
+    """A Pyscript Binary Sensor Entity"""
     platform = PLATFORM
 
-    def init(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._device_class = None
 
     @property
@@ -24,9 +28,10 @@ class PyscriptBinarySensor(PyscriptEntity):
         return self._device_class
 
     # TO BE USED IN PYSCRIPT
-    ######################################        
+    ######################################
 
     def set_state(self, state):
+        """Handle State Validation"""
         if state is True:
             state = "on"
 
@@ -35,11 +40,12 @@ class PyscriptBinarySensor(PyscriptEntity):
 
         state = state.lower()
 
-        if state not in ('on', 'off'):
+        if state not in ("on", "off"):
             raise ValueError('BinarySensor state must be "on" or "off"')
 
-        self._state = state
+        super().set_state(state)
 
     async def set_device_class(self, device_class):
+        """Set Device Class of Entity"""
         self._device_class = device_class
         await self.async_update()

--- a/custom_components/pyscript/entity_manager.py
+++ b/custom_components/pyscript/entity_manager.py
@@ -1,0 +1,32 @@
+class EntityManager:
+
+    hass = None
+
+    platform_adders = {}
+    platform_classes = {}
+    registered_entities = {}
+
+
+    @classmethod
+    def init(cls, hass):
+        cls.hass = hass
+
+    @classmethod
+    def register_platform(cls, platform, adder, entity_class):
+        cls.platform_adders[platform] = adder
+        cls.platform_classes[platform] = entity_class
+        cls.registered_entities[platform] = {}
+
+    @classmethod
+    def get(cls, platform, name):
+        if platform not in cls.registered_entities or name not in cls.registered_entities[platform]:
+            cls.create(platform, name)
+
+        return cls.registered_entities[platform][name]
+
+    @classmethod
+    def create(cls, platform, name):
+        new_entity = cls.platform_classes[platform](cls.hass, name)
+        cls.platform_adders[platform]([new_entity])
+        cls.registered_entities[platform][name] = new_entity
+        

--- a/custom_components/pyscript/entity_manager.py
+++ b/custom_components/pyscript/entity_manager.py
@@ -1,3 +1,10 @@
+from homeassistant.helpers.entity import Entity
+from .const import DOMAIN, LOGGER_PATH
+import logging
+
+_LOGGER = logging.getLogger(LOGGER_PATH + ".entity_manager")
+
+
 class EntityManager:
 
     hass = None
@@ -30,3 +37,73 @@ class EntityManager:
         cls.platform_adders[platform]([new_entity])
         cls.registered_entities[platform][name] = new_entity
         
+
+class PyscriptEntity(Entity):
+
+    def __init__(self, hass, unique_id):
+        self._added = False
+        self.hass = hass
+
+        self._unique_id = f"{DOMAIN}_{self.platform}_{unique_id}"
+
+        self._state = None
+        self._attributes = {}
+        self._icon = None
+
+
+        _LOGGER.debug(
+            "Entity Initialized %s",
+            self._unique_id,
+        )
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return attributes for the sensor."""
+        return self._attributes
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
+
+    async def async_added_to_hass(self):
+        self._added = True
+        await self.async_update()
+
+    async def async_update(self):
+        self.async_write_ha_state()
+
+
+    # TO BE USED IN PYSCRIPT
+    ######################################
+
+    async def set(self, state=None, new_attributes=None, **kwargs):
+        if state is not None:
+            self._state = state
+
+        if new_attributes is not None:
+            self._attributes = new_attributes
+
+        for attribute_name in kwargs:
+            self._attributes[attribute_name] = kwargs[attribute_name]
+
+
+        _LOGGER.debug(
+            "%s state is now %s (%s)",
+            self._unique_id,
+            self._state,
+            self._attributes,
+        )
+
+        if self._added:
+            await self.async_update()

--- a/custom_components/pyscript/entity_manager.py
+++ b/custom_components/pyscript/entity_manager.py
@@ -80,21 +80,6 @@ class PyscriptEntity(Entity):
     ####################################
 
     @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
-    @property
-    def device_state_attributes(self):
-        """Return attributes for the sensor."""
-        attributes = dict(self._attributes)
-        attributes.update({
-            "_unique_id": self._unique_id,
-            "_global_ctx": self.ast_ctx.name,
-        })
-        return attributes
-
-    @property
     def icon(self):
         """Return the icon to use in the frontend, if any."""
         return self._icon
@@ -109,6 +94,19 @@ class PyscriptEntity(Entity):
         """Return a unique ID."""
         return self._unique_id
 
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes."""
+        return {
+            "_unique_id": self._unique_id,
+            "_global_ctx": self.ast_ctx.name,
+        }
+
     async def async_added_to_hass(self):
         """Called when Home Assistant adds the entity to the registry"""    
         self._added = True
@@ -118,6 +116,7 @@ class PyscriptEntity(Entity):
             self._unique_id,
             self.entity_id,
         )
+
 
     # USED INTERNALLY
     #####################################

--- a/custom_components/pyscript/entity_manager.py
+++ b/custom_components/pyscript/entity_manager.py
@@ -63,13 +63,13 @@ class PyscriptEntity(Entity):
         self.hass = hass
         self.ast_ctx = ast_ctx
 
-        self._unique_id = unique_id
+        self._unique_id = f"{self.platform}_{unique_id}"
 
         self._state = None
         self._attributes = {}
 
         self._icon = None
-        self._name = None
+        self._name = unique_id
 
         _LOGGER.debug(
             "Entity Initialized %s",
@@ -84,7 +84,12 @@ class PyscriptEntity(Entity):
     @property
     def device_state_attributes(self):
         """Return attributes for the sensor."""
-        return self._attributes
+        attributes = dict(self._attributes)
+        attributes.update({
+            "_unique_id": self._unique_id,
+            "_global_ctx": self.ast_ctx.name,
+        })
+        return attributes
 
     @property
     def icon(self):
@@ -102,7 +107,7 @@ class PyscriptEntity(Entity):
         return self._unique_id
 
     async def async_added_to_hass(self):
-        """Called when Home Assistant adds the entity to the registry"""
+        """Called when Home Assistant adds the entity to the registry"""    
         self._added = True
         await self.async_update()
 
@@ -110,6 +115,7 @@ class PyscriptEntity(Entity):
         """Request an entity update from Home Assistant"""
         if self._added:
             self.async_write_ha_state()
+
 
     # OPTIONALLY OVERRIDDEN IN EXTENDED CLASSES
     #####################################

--- a/custom_components/pyscript/entity_manager.py
+++ b/custom_components/pyscript/entity_manager.py
@@ -83,19 +83,28 @@ class PyscriptEntity(Entity):
     async def async_update(self):
         self.async_write_ha_state()
 
+    def set_state(self, state):
+        self._state = state
+
+    def set_attribute(self, attribute, value):
+        self._attributes[attribute] = value
+
+    def set_all_attributes(self, attributes={}):
+        self._attributes = attributes
+
 
     # TO BE USED IN PYSCRIPT
     ######################################
 
     async def set(self, state=None, new_attributes=None, **kwargs):
         if state is not None:
-            self._state = state
+            self.set_state(state)
 
         if new_attributes is not None:
-            self._attributes = new_attributes
+            self.set_all_attributes(new_attributes)
 
         for attribute_name in kwargs:
-            self._attributes[attribute_name] = kwargs[attribute_name]
+            self.set_attribute(attribute_name, kwargs[attribute_name])
 
 
         _LOGGER.debug(

--- a/custom_components/pyscript/entity_manager.py
+++ b/custom_components/pyscript/entity_manager.py
@@ -117,6 +117,12 @@ class PyscriptEntity(Entity):
             self.entity_id,
         )
 
+    @property
+    def should_poll(self):
+        """Return True if entity has to be polled for state.
+        False if entity pushes its state to HA.
+        """
+        return False
 
     # USED INTERNALLY
     #####################################

--- a/custom_components/pyscript/entity_manager.py
+++ b/custom_components/pyscript/entity_manager.py
@@ -25,24 +25,25 @@ class EntityManager:
         cls.registered_entities[platform] = {}
 
     @classmethod
-    def get(cls, platform, name):
+    def get(cls, ast_ctx, platform, name):
         if platform not in cls.registered_entities or name not in cls.registered_entities[platform]:
-            cls.create(platform, name)
+            cls.create(ast_ctx, platform, name)
 
         return cls.registered_entities[platform][name]
 
     @classmethod
-    def create(cls, platform, name):
-        new_entity = cls.platform_classes[platform](cls.hass, name)
+    def create(cls, ast_ctx, platform, name):
+        new_entity = cls.platform_classes[platform](cls.hass, ast_ctx, name)
         cls.platform_adders[platform]([new_entity])
         cls.registered_entities[platform][name] = new_entity
         
 
 class PyscriptEntity(Entity):
 
-    def __init__(self, hass, unique_id):
+    def __init__(self, hass, ast_ctx, unique_id):
         self._added = False
         self.hass = hass
+        self.ast_ctx = ast_ctx
 
         self._unique_id = f"{DOMAIN}_{self.platform}_{unique_id}"
 
@@ -55,6 +56,8 @@ class PyscriptEntity(Entity):
             "Entity Initialized %s",
             self._unique_id,
         )
+
+        self.init()
 
     @property
     def state(self):
@@ -83,6 +86,9 @@ class PyscriptEntity(Entity):
     async def async_update(self):
         self.async_write_ha_state()
 
+    # OPTIONALLY OVERRIDDEN IN EXTENDED CLASSES
+    #####################################
+
     def set_state(self, state):
         self._state = state
 
@@ -91,6 +97,9 @@ class PyscriptEntity(Entity):
 
     def set_all_attributes(self, attributes={}):
         self._attributes = attributes
+
+    def init(self):
+        pass
 
 
     # TO BE USED IN PYSCRIPT

--- a/custom_components/pyscript/entity_manager.py
+++ b/custom_components/pyscript/entity_manager.py
@@ -122,7 +122,7 @@ class PyscriptEntity(Entity):
         """Set a single attribute"""
         self._attributes[attribute] = value
 
-    def set_all_attributes(self, attributes={}):
+    def set_all_attributes(self, attributes):
         """Set all Attributes and clear existing values"""
         self._attributes = attributes
 

--- a/custom_components/pyscript/function.py
+++ b/custom_components/pyscript/function.py
@@ -91,7 +91,6 @@ class Function:
                 "task.remove_done_callback": cls.user_task_remove_done_callback,
                 "task.sleep": cls.async_sleep,
                 "task.wait": cls.user_task_wait,
-                "em": EntityManager,
             }
         )
         cls.ast_functions.update(

--- a/custom_components/pyscript/function.py
+++ b/custom_components/pyscript/function.py
@@ -103,6 +103,7 @@ class Function:
                 "print": lambda ast_ctx: ast_ctx.get_logger().debug,
                 "task.name2id": cls.task_name2id_factory,
                 "task.unique": cls.task_unique_factory,
+                "em": cls.entity_manager_get_factory,
             }
         )
 
@@ -202,6 +203,14 @@ class Function:
     async def async_sleep(cls, duration):
         """Implement task.sleep()."""
         await asyncio.sleep(float(duration))
+
+    @classmethod
+    def entity_manager_get_factory(cls, ctx):
+        
+        async def entity_manager_get(platform, name):
+            return EntityManager.get(ctx, platform, name)
+
+        return entity_manager_get
 
     @classmethod
     async def event_fire(cls, event_type, **kwargs):

--- a/custom_components/pyscript/function.py
+++ b/custom_components/pyscript/function.py
@@ -8,6 +8,7 @@ import traceback
 from homeassistant.core import Context
 
 from .const import LOGGER_PATH
+from .entity_manager import EntityManager
 
 _LOGGER = logging.getLogger(LOGGER_PATH + ".function")
 
@@ -90,6 +91,7 @@ class Function:
                 "task.remove_done_callback": cls.user_task_remove_done_callback,
                 "task.sleep": cls.async_sleep,
                 "task.wait": cls.user_task_wait,
+                "em": EntityManager,
             }
         )
         cls.ast_functions.update(

--- a/custom_components/pyscript/function.py
+++ b/custom_components/pyscript/function.py
@@ -206,8 +206,10 @@ class Function:
 
     @classmethod
     def entity_manager_get_factory(cls, ctx):
+        """Define and return em for this context."""
         
         async def entity_manager_get(platform, name):
+            """Implement em"""
             return await EntityManager.get(ctx, platform, name)
 
         return entity_manager_get

--- a/custom_components/pyscript/function.py
+++ b/custom_components/pyscript/function.py
@@ -208,7 +208,7 @@ class Function:
     def entity_manager_get_factory(cls, ctx):
         
         async def entity_manager_get(platform, name):
-            return EntityManager.get(ctx, platform, name)
+            return await EntityManager.get(ctx, platform, name)
 
         return entity_manager_get
 

--- a/custom_components/pyscript/sensor.py
+++ b/custom_components/pyscript/sensor.py
@@ -1,6 +1,7 @@
-from homeassistant.helpers.entity import Entity
 from .const import DOMAIN
-from .entity_manager import EntityManager
+from .entity_manager import EntityManager, PyscriptEntity
+
+PLATFORM = 'sensor'
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     EntityManager.register_platform('sensor', async_add_entities, PyscriptSensor)
@@ -11,52 +12,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
 
 
-class PyscriptSensor(Entity):
-
-    def __init__(self, hass, name):
-        self._added = False
-        self.hass = hass
-
-        self._name = name
-        self._state = None
-        self._attributes = {}
-
-        self._unique_id = f"{DOMAIN}_sensor_{self._name}"
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
-    @property
-    def device_state_attributes(self):
-        """Return attributes for the sensor."""
-        return self._attributes
-
-    @property
-    def icon(self):
-        """Return the icon to use in the frontend, if any."""
-        return "mdi:home"
-
-    @property
-    def unique_id(self):
-        """Return a unique ID."""
-        return self._unique_id
-
-    async def async_added_to_hass(self):
-        self._added = True
-        await self.async_update()
-
-    async def set_state(self, state):
-        self._state = state
-        if self._added:
-            await self.async_update()
-
-    async def async_update(self):
-        self.async_write_ha_state()
+class PyscriptSensor(PyscriptEntity):
+    platform = PLATFORM
 

--- a/custom_components/pyscript/sensor.py
+++ b/custom_components/pyscript/sensor.py
@@ -1,0 +1,70 @@
+from homeassistant.helpers.entity import Entity
+from .const import DOMAIN
+
+ENTITY_ADDER = None
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    global ENTITY_ADDER
+
+    # async_add_entities([VersionSensor(haversion, name)], True)
+    ENTITY_ADDER = async_add_entities
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    return await async_setup_platform(
+        hass, config_entry.data, async_add_entities, discovery_info=None
+    )
+
+async def create(hass, name):
+    new_sensor = PyscriptSensor(hass, name)
+    ENTITY_ADDER([new_sensor])
+    return new_sensor
+
+class PyscriptSensor(Entity):
+
+    def __init__(self, hass, name):
+        self._added = False
+        self.hass = hass
+
+        self._name = name
+        self._state = None
+        self._attributes = {}
+
+        self._unique_id = f"{DOMAIN}_sensor_{self._name}"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return attributes for the sensor."""
+        return self._attributes
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:home"
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
+
+    async def async_added_to_hass(self):
+        self._added = True
+        await self.async_update()
+
+    async def set_state(self, state):
+        self._state = state
+        if self._added:
+            await self.async_update()
+
+    async def async_update(self):
+        self.async_write_ha_state()
+

--- a/custom_components/pyscript/sensor.py
+++ b/custom_components/pyscript/sensor.py
@@ -1,5 +1,6 @@
 """Pyscript Sensor Entity"""
 from .entity_manager import EntityManager, PyscriptEntity
+from homeassistant.helpers.entity import Entity
 
 PLATFORM = "sensor"
 
@@ -14,7 +15,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     return await async_setup_platform(hass, config_entry.data, async_add_entities, discovery_info=None)
 
 
-class PyscriptSensor(PyscriptEntity):
+# inheriting from Entity here because HASS doesn't have SensorEntity
+class PyscriptSensor(PyscriptEntity, Entity):
     """A Pyscript Sensor Entity"""
     platform = PLATFORM
 
@@ -22,6 +24,15 @@ class PyscriptSensor(PyscriptEntity):
         super().__init__(*args, **kwargs)
         self._device_class = None
         self._unit_of_measurement = None
+
+
+    # USED BY HOME ASSISTANT
+    ##############################
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state    
 
     @property
     def device_class(self):
@@ -33,7 +44,8 @@ class PyscriptSensor(PyscriptEntity):
         """Return the unit of measurement for the sensor."""
         return self._unit_of_measurement
 
-    # TO BE USED IN PYSCRIPT
+
+    # USED IN PYSCRIPT
     ######################################
 
     async def set_device_class(self, device_class):

--- a/custom_components/pyscript/sensor.py
+++ b/custom_components/pyscript/sensor.py
@@ -1,23 +1,15 @@
 from homeassistant.helpers.entity import Entity
 from .const import DOMAIN
-
-ENTITY_ADDER = None
+from .entity_manager import EntityManager
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    global ENTITY_ADDER
-
-    # async_add_entities([VersionSensor(haversion, name)], True)
-    ENTITY_ADDER = async_add_entities
+    EntityManager.register_platform('sensor', async_add_entities, PyscriptSensor)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     return await async_setup_platform(
         hass, config_entry.data, async_add_entities, discovery_info=None
     )
 
-async def create(hass, name):
-    new_sensor = PyscriptSensor(hass, name)
-    ENTITY_ADDER([new_sensor])
-    return new_sensor
 
 class PyscriptSensor(Entity):
 

--- a/custom_components/pyscript/sensor.py
+++ b/custom_components/pyscript/sensor.py
@@ -15,3 +15,27 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class PyscriptSensor(PyscriptEntity):
     platform = PLATFORM
 
+    def init(self):
+        self._device_class = None
+        self._unit_of_measurement = None
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return self._device_class
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement for the sensor."""
+        return self._unit_of_measurement
+
+    # TO BE USED IN PYSCRIPT
+    ######################################
+
+    async def set_device_class(self, device_class):
+        self._device_class = device_class
+        await self.async_update()
+
+    async def set_unit(self, unit):
+        self._unit_of_measurement = unit
+        await self.async_update()

--- a/custom_components/pyscript/sensor.py
+++ b/custom_components/pyscript/sensor.py
@@ -4,7 +4,7 @@ from .entity_manager import EntityManager, PyscriptEntity
 PLATFORM = 'sensor'
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    EntityManager.register_platform('sensor', async_add_entities, PyscriptSensor)
+    EntityManager.register_platform(PLATFORM, async_add_entities, PyscriptSensor)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     return await async_setup_platform(

--- a/custom_components/pyscript/sensor.py
+++ b/custom_components/pyscript/sensor.py
@@ -1,21 +1,25 @@
-from .const import DOMAIN
+"""Pyscript Sensor Entity"""
 from .entity_manager import EntityManager, PyscriptEntity
 
-PLATFORM = 'sensor'
+PLATFORM = "sensor"
+
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Initialize Pyscript Sensor Platform"""
     EntityManager.register_platform(PLATFORM, async_add_entities, PyscriptSensor)
 
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    return await async_setup_platform(
-        hass, config_entry.data, async_add_entities, discovery_info=None
-    )
+    """Initialize Pyscript Sensor Config"""
+    return await async_setup_platform(hass, config_entry.data, async_add_entities, discovery_info=None)
 
 
 class PyscriptSensor(PyscriptEntity):
+    """A Pyscript Sensor Entity"""
     platform = PLATFORM
 
-    def init(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._device_class = None
         self._unit_of_measurement = None
 
@@ -33,9 +37,11 @@ class PyscriptSensor(PyscriptEntity):
     ######################################
 
     async def set_device_class(self, device_class):
+        """Set device class of entity"""
         self._device_class = device_class
         await self.async_update()
 
     async def set_unit(self, unit):
+        """Set unit_of_measurement of entity"""
         self._unit_of_measurement = unit
         await self.async_update()

--- a/custom_components/pyscript/switch.py
+++ b/custom_components/pyscript/switch.py
@@ -1,0 +1,38 @@
+from .const import DOMAIN
+from .entity_manager import EntityManager, PyscriptEntity
+
+PLATFORM = 'switch'
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    EntityManager.register_platform(PLATFORM, async_add_entities, PyscriptSwitch)
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    return await async_setup_platform(
+        hass, config_entry.data, async_add_entities, discovery_info=None
+    )
+
+
+class PyscriptSwitch(PyscriptEntity):
+    platform = PLATFORM
+
+    def init(self):
+        self._turn_on_handler = None
+        self._turn_off_handler = None
+
+    def on_turn_on(self, func):
+        self._turn_on_handler = func
+
+    def on_turn_off(self, func):
+        self._turn_off_handler = func
+
+    async def async_turn_on(self, **kwargs):
+        if self._turn_on_handler is None:
+            return
+
+        await self._turn_on_handler.call(self.ast_ctx, self, **kwargs)
+
+    async def async_turn_off(self, **kwargs):
+        if self._turn_off_handler is None:
+            return
+
+        await self._turn_off_handler.call(self.ast_ctx, self, **kwargs)

--- a/custom_components/pyscript/switch.py
+++ b/custom_components/pyscript/switch.py
@@ -25,14 +25,6 @@ class PyscriptSwitch(PyscriptEntity):
         self._turn_on_handler = None
         self._turn_off_handler = None
 
-    def on_turn_on(self, func):
-        """Setup handler for turn_on functionality"""
-        self._turn_on_handler = func
-
-    def on_turn_off(self, func):
-        """Setup handler for turn_off functionality"""
-        self._turn_off_handler = func
-
     async def async_turn_on(self, **kwargs):
         """Handle turn_on request."""
         if self._turn_on_handler is None:
@@ -65,3 +57,14 @@ class PyscriptSwitch(PyscriptEntity):
             raise ValueError('Switch state must be "on" or "off"')
 
         super().set_state(state)
+
+    # TO BE USED IN PYSCRIPT
+    ######################################
+
+    def on_turn_on(self, func):
+        """Setup handler for turn_on functionality"""
+        self._turn_on_handler = func
+
+    def on_turn_off(self, func):
+        """Setup handler for turn_off functionality"""
+        self._turn_off_handler = func

--- a/custom_components/pyscript/switch.py
+++ b/custom_components/pyscript/switch.py
@@ -1,5 +1,6 @@
 """Pyscript Switch Entity"""
 from .entity_manager import EntityManager, PyscriptEntity
+from homeassistant.helpers.entity import ToggleEntity
 from .eval import EvalFunc
 
 PLATFORM = "switch"
@@ -15,7 +16,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     return await async_setup_platform(hass, config_entry.data, async_add_entities, discovery_info=None)
 
 
-class PyscriptSwitch(PyscriptEntity):
+class PyscriptSwitch(PyscriptEntity, ToggleEntity):
     """A Pysript Switch Entity"""
     platform = PLATFORM
 
@@ -24,6 +25,16 @@ class PyscriptSwitch(PyscriptEntity):
         super().__init__(*args, **kwargs)
         self._turn_on_handler = None
         self._turn_off_handler = None
+
+
+    # USED BY HOME ASSISTANT
+    ##############################
+    @property
+    def is_on(self):
+        """Return true if binary sensor is on"""
+        if self._state == 'on':
+            return True
+        return False
 
     async def async_turn_on(self, **kwargs):
         """Handle turn_on request."""
@@ -49,6 +60,9 @@ class PyscriptSwitch(PyscriptEntity):
         else:
             raise RuntimeError(f"Unable to Call turn_off_handler of type {type(self._turn_off_handler)}")
 
+    # OVERRIDDEN FROM PyscriptEntity
+    ################################ 
+
     def set_state(self, state):
         """Handle state validation"""
         state = state.lower()
@@ -58,7 +72,7 @@ class PyscriptSwitch(PyscriptEntity):
 
         super().set_state(state)
 
-    # TO BE USED IN PYSCRIPT
+    # USED IN PYSCRIPT
     ######################################
 
     def on_turn_on(self, func):

--- a/custom_components/pyscript/switch.py
+++ b/custom_components/pyscript/switch.py
@@ -1,32 +1,40 @@
-from .const import DOMAIN
+"""Pyscript Switch Entity"""
 from .entity_manager import EntityManager, PyscriptEntity
 from .eval import EvalFunc
 
-PLATFORM = 'switch'
+PLATFORM = "switch"
+
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Initialize Pyscript Switch Platform"""
     EntityManager.register_platform(PLATFORM, async_add_entities, PyscriptSwitch)
 
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    return await async_setup_platform(
-        hass, config_entry.data, async_add_entities, discovery_info=None
-    )
+    """Initialize Pyscript Switch Config"""
+    return await async_setup_platform(hass, config_entry.data, async_add_entities, discovery_info=None)
 
 
 class PyscriptSwitch(PyscriptEntity):
+    """A Pysript Switch Entity"""
     platform = PLATFORM
 
-    def init(self):
+    def __init__(self, *args, **kwargs):
+        """Initialize Pyscript Switch"""
+        super().__init__(*args, **kwargs)
         self._turn_on_handler = None
         self._turn_off_handler = None
 
     def on_turn_on(self, func):
+        """Setup handler for turn_on functionality"""
         self._turn_on_handler = func
 
     def on_turn_off(self, func):
+        """Setup handler for turn_off functionality"""
         self._turn_off_handler = func
 
     async def async_turn_on(self, **kwargs):
+        """Handle turn_on request."""
         if self._turn_on_handler is None:
             return
 
@@ -38,6 +46,7 @@ class PyscriptSwitch(PyscriptEntity):
             raise RuntimeError(f"Unable to Call turn_on_handler of type {type(self._turn_on_handler)}")
 
     async def async_turn_off(self, **kwargs):
+        """Handle turn_off request."""
         if self._turn_off_handler is None:
             return
 
@@ -49,9 +58,10 @@ class PyscriptSwitch(PyscriptEntity):
             raise RuntimeError(f"Unable to Call turn_off_handler of type {type(self._turn_off_handler)}")
 
     def set_state(self, state):
+        """Handle state validation"""
         state = state.lower()
 
-        if state not in ('on', 'off'):
+        if state not in ("on", "off"):
             raise ValueError('Switch state must be "on" or "off"')
-            
-        self._state = state
+
+        super().set_state(state)

--- a/custom_components/pyscript/switch.py
+++ b/custom_components/pyscript/switch.py
@@ -1,5 +1,6 @@
 from .const import DOMAIN
 from .entity_manager import EntityManager, PyscriptEntity
+from .eval import EvalFunc
 
 PLATFORM = 'switch'
 
@@ -29,10 +30,28 @@ class PyscriptSwitch(PyscriptEntity):
         if self._turn_on_handler is None:
             return
 
-        await self._turn_on_handler.call(self.ast_ctx, self, **kwargs)
+        if callable(self._turn_on_handler):
+            await self._turn_on_handler(self, **kwargs)
+        elif isinstance(self._turn_on_handler, EvalFunc):
+            await self._turn_on_handler.call(self.ast_ctx, self, **kwargs)
+        else:
+            raise RuntimeError(f"Unable to Call turn_on_handler of type {type(self._turn_on_handler)}")
 
     async def async_turn_off(self, **kwargs):
         if self._turn_off_handler is None:
             return
 
-        await self._turn_off_handler.call(self.ast_ctx, self, **kwargs)
+        if callable(self._turn_off_handler):
+            await self._turn_off_handler(self, **kwargs)
+        elif isinstance(self._turn_off_handler, EvalFunc):
+            await self._turn_off_handler.call(self.ast_ctx, self, **kwargs)
+        else:
+            raise RuntimeError(f"Unable to Call turn_off_handler of type {type(self._turn_off_handler)}")
+
+    def set_state(self, state):
+        state = state.lower()
+
+        if state not in ('on', 'off'):
+            raise ValueError('Switch state must be "on" or "off"')
+            
+        self._state = state


### PR DESCRIPTION
Implement Native Home Assistant Entities (through the Entity Registry) in Pyscript. 

In comparison to a simple `state.set('domain.entity', value)` it offers several features:

1) visualize all entities in the pyscript integration
2) renaming entity_ids
3) grouping entities into devices (device management will be a future PR)
4) handling service calls against entities (i.e. `switch.turn_on` for a switch)

If you'd prefer to not have this in pyscript, I can build it as a separate custom_component designed to integrate well with pyscript (though useful without it as well). 

Needed: 
1) variable name to attach entity manager to in pyscript (using `em` during testing)
1) using the entity manager directly in a pyscript (i.e. not inside of a function) doesn't always work because sometimes the pyscript loads before the platform loads. Looking to find a way to delay pyscript loading until after platforms have loaded, or, for a way to properly handle waiting for the platform to load if it's requested before it's ready. All attempts so far have left Home Assistant locked until the entity manager times out. (see `EntityManager.wait_for_platform_register()`)

Missing: 
1) DOCS
1) TESTS