### PR TITLE
update services.yaml schema to support 2021.3

### DIFF
--- a/custom_components/pyscript/services.yaml
+++ b/custom_components/pyscript/services.yaml
@@ -6,7 +6,7 @@ reload:
   fields:
     global_ctx:
       name: Global Context
-      description: only reload this specific global context (file or app)
+      description: Only reload this specific global context (file or app)
       example: file.example
       required: false
       selector:
@@ -18,6 +18,7 @@ jupyter_kernel_start:
   fields:
     shell_port:
       name: Shell Port Number
+      description: Shell port number
       example: 63599
       required: false
       selector:
@@ -26,6 +27,7 @@ jupyter_kernel_start:
           max: 65535
     iopub_port:
       name: IOPub Port Number
+      description: IOPub port number
       example: 63598
       required: false
       selector:
@@ -34,6 +36,7 @@ jupyter_kernel_start:
           max: 65535
     stdin_port:
       name: Stdin Port Number
+      description: Stdin port number
       example: 63597
       required: false
       selector:
@@ -42,6 +45,7 @@ jupyter_kernel_start:
           max: 65535
     control_port:
       name: Control Port Number
+      description: Control port number
       example: 63596
       required: false
       selector:
@@ -50,6 +54,7 @@ jupyter_kernel_start:
           max: 65535
     hb_port:
       name: Heartbeat Port Number
+      description: Heartbeat port number
       example: 63595
       required: false
       selector:
@@ -73,6 +78,7 @@ jupyter_kernel_start:
         text:
     transport:
       name: Transport Type
+      description: Transport type
       example: tcp
       default: tcp
       required: false
@@ -83,6 +89,7 @@ jupyter_kernel_start:
             - udp
     signature_scheme:
       name: Signing Algorithm
+      description: Signing algorithm
       example: hmac-sha256
       required: false
       default: hmac-sha256
@@ -92,6 +99,7 @@ jupyter_kernel_start:
             - hmac-sha256
     kernel_name:
       name: Name of Kernel
+      description: Kernel name
       example: pyscript
       required: true
       default: pyscript

--- a/custom_components/pyscript/services.yaml
+++ b/custom_components/pyscript/services.yaml
@@ -1,9 +1,11 @@
 # Describes the format for available pyscript services
 
 reload:
-  description: Reload all available pyscripts and restart triggers
+  name: Reload pyscript
+  description: Reloads all available pyscripts and restart triggers
   fields:
     global_ctx:
+      name: Global Context
       description: only reload this specific global context (file or app)
       example: file.example
       required: false
@@ -11,10 +13,11 @@ reload:
         text:
 
 jupyter_kernel_start:
-  description: Start a jupyter kernel for interactive use; called by Jupyter front end
+  name: Start Jupyter kernel
+  description: Starts a jupyter kernel for interactive use; called by Jupyter front end
   fields:
     shell_port:
-      description: shell port number
+      name: Shell Port Number
       example: 63599
       required: false
       selector:
@@ -22,7 +25,7 @@ jupyter_kernel_start:
           min: 49152
           max: 65535
     iopub_port:
-      description: iopub port number
+      name: IOPub Port Number
       example: 63598
       required: false
       selector:
@@ -30,7 +33,7 @@ jupyter_kernel_start:
           min: 49152
           max: 65535
     stdin_port:
-      description: stdin port number
+      name: Stdin Port Number
       example: 63597
       required: false
       selector:
@@ -38,7 +41,7 @@ jupyter_kernel_start:
           min: 49152
           max: 65535
     control_port:
-      description: control port number
+      name: Control Port Number
       example: 63596
       required: false
       selector:
@@ -46,7 +49,7 @@ jupyter_kernel_start:
           min: 49152
           max: 65535
     hb_port:
-      description: heartbeat port number
+      name: Heartbeat Port Number
       example: 63595
       required: false
       selector:
@@ -54,20 +57,22 @@ jupyter_kernel_start:
           min: 49152
           max: 65535
     ip:
-      description: ip address to connect to jupyter front end
+      name: IP Address
+      description: IP address to connect to Jupyter front end
       example: 127.0.0.1
       default: 127.0.0.1
       required: false
       selector:
         text:
     key:
-      description: security key for signing
+      name: Security Key
+      description: Used for signing
       example: 012345678-9abcdef023456789abcdef
       required: true
       selector:
         text:
     transport:
-      description: type of transport
+      name: Transport Type
       example: tcp
       default: tcp
       required: false
@@ -77,7 +82,7 @@ jupyter_kernel_start:
             - tcp
             - udp
     signature_scheme:
-      description: signing algorithm
+      name: Signing Algorithm
       example: hmac-sha256
       required: false
       default: hmac-sha256
@@ -86,7 +91,7 @@ jupyter_kernel_start:
           options:
             - hmac-sha256
     kernel_name:
-      description: name of kernel
+      name: Name of Kernel
       example: pyscript
       required: true
       default: pyscript

--- a/custom_components/pyscript/services.yaml
+++ b/custom_components/pyscript/services.yaml
@@ -14,7 +14,7 @@ reload:
 
 jupyter_kernel_start:
   name: Start Jupyter kernel
-  description: Starts a jupyter kernel for interactive use; called by Jupyter front end
+  description: Starts a jupyter kernel for interactive use; Called by Jupyter front end and should generally not be used by users
   fields:
     shell_port:
       name: Shell Port Number
@@ -23,7 +23,7 @@ jupyter_kernel_start:
       required: false
       selector:
         number:
-          min: 49152
+          min: 10240
           max: 65535
     iopub_port:
       name: IOPub Port Number
@@ -32,7 +32,7 @@ jupyter_kernel_start:
       required: false
       selector:
         number:
-          min: 49152
+          min: 10240
           max: 65535
     stdin_port:
       name: Stdin Port Number
@@ -41,7 +41,7 @@ jupyter_kernel_start:
       required: false
       selector:
         number:
-          min: 49152
+          min: 10240
           max: 65535
     control_port:
       name: Control Port Number
@@ -50,7 +50,7 @@ jupyter_kernel_start:
       required: false
       selector:
         number:
-          min: 49152
+          min: 10240
           max: 65535
     hb_port:
       name: Heartbeat Port Number
@@ -59,7 +59,7 @@ jupyter_kernel_start:
       required: false
       selector:
         number:
-          min: 49152
+          min: 10240
           max: 65535
     ip:
       name: IP Address

--- a/custom_components/pyscript/services.yaml
+++ b/custom_components/pyscript/services.yaml
@@ -6,6 +6,9 @@ reload:
     global_ctx:
       description: only reload this specific global context (file or app)
       example: file.example
+      required: false
+      selector:
+        text:
 
 jupyter_kernel_start:
   description: Start a jupyter kernel for interactive use; called by Jupyter front end
@@ -13,30 +16,79 @@ jupyter_kernel_start:
     shell_port:
       description: shell port number
       example: 63599
+      required: false
+      selector:
+        number:
+          min: 49152
+          max: 65535
     iopub_port:
       description: iopub port number
       example: 63598
+      required: false
+      selector:
+        number:
+          min: 49152
+          max: 65535
     stdin_port:
       description: stdin port number
       example: 63597
+      required: false
+      selector:
+        number:
+          min: 49152
+          max: 65535
     control_port:
       description: control port number
       example: 63596
+      required: false
+      selector:
+        number:
+          min: 49152
+          max: 65535
     hb_port:
       description: heartbeat port number
       example: 63595
+      required: false
+      selector:
+        number:
+          min: 49152
+          max: 65535
     ip:
       description: ip address to connect to jupyter front end
       example: 127.0.0.1
+      default: 127.0.0.1
+      required: false
+      selector:
+        text:
     key:
       description: security key for signing
       example: 012345678-9abcdef023456789abcdef
+      required: true
+      selector:
+        text:
     transport:
       description: type of transport
       example: tcp
+      default: tcp
+      required: false
+      selector:
+        select:
+          options:
+            - tcp
+            - udp
     signature_scheme:
       description: signing algorithm
       example: hmac-sha256
+      required: false
+      default: hmac-sha256
+      selector:
+        select:
+          options:
+            - hmac-sha256
     kernel_name:
       description: name of kernel
       example: pyscript
+      required: true
+      default: pyscript
+      selector:
+        text:


### PR DESCRIPTION
Updated `services.yaml` but wasn't sure if I got the required value right for all parameters of `jupyter_kernel_start`. Can you review and let me know which, if any, need to be updated?

These changes are not required but they do make calling the services from within the UI more friendly.