### PR TITLE
Added support for service responses when calling or creating services.

### DIFF
--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -15,6 +15,7 @@ import weakref
 
 import yaml
 
+from homeassistant.core import SupportsResponse
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.helpers.service import async_set_service_schema
 
@@ -377,6 +378,7 @@ class EvalFunc:
             "time_trigger": {"kwargs": {dict}},
             "task_unique": {"kill_me": {bool, int}},
             "time_active": {"hold_off": {int, float}},
+            "service": {"supports_response": {str}},
             "state_trigger": {
                 "kwargs": {dict},
                 "state_hold": {int, float},
@@ -485,11 +487,14 @@ class EvalFunc:
                         func_args.update(call.data)
 
                         async def do_service_call(func, ast_ctx, data):
-                            await func.call(ast_ctx, **data)
+                            retval = await func.call(ast_ctx, **data)
                             if ast_ctx.get_exception_obj():
                                 ast_ctx.get_logger().error(ast_ctx.get_exception_long())
+                            return retval
 
-                        Function.create_task(do_service_call(func, ast_ctx, func_args))
+                        task = Function.create_task(do_service_call(func, ast_ctx, func_args))
+                        await task
+                        return task.result()
 
                     return pyscript_service_handler
 
@@ -500,7 +505,7 @@ class EvalFunc:
                     if name in (SERVICE_RELOAD, SERVICE_JUPYTER_KERNEL_START):
                         raise SyntaxError(f"{exc_mesg}: @service conflicts with builtin service")
                     Function.service_register(
-                        trig_ctx_name, domain, name, pyscript_service_factory(func_name, self)
+                        trig_ctx_name, domain, name, pyscript_service_factory(func_name, self), dec_kwargs.get("supports_response", SupportsResponse.NONE)
                     )
                     async_set_service_schema(Function.hass, domain, name, service_desc)
                     self.trigger_service.add(srv_name)


### PR DESCRIPTION
# Added support for returning service responses for both service execution and service creating.

## Calling Services:

- Added argument "return_response" to be passed to the call to the underlying home assistant service API.
- Added "return" to several places so that executed service calls can actually return values.
- Added some convenience functionality so that the user does not need to explicitly specify arguments "return_response" or "blocking" when calling a service which returns a response.

The user can now call services and get responses back. This works for both ways of calling services, via service.call() and also when using the service name as a function. Users can now use the argument "return_response = True" when they are interested in getting a response like this:

`retval = service.call("mydomain", "myservice", return_response = True, ...)`

or

`retval = mydomain.myservice(return_response = True, ...)`

When the called service has been created with "SupportsResponse.ONLY", then "return_response = True" is automatically assumed when not explicitly given by the user.

## Creating service:
- Decorator @service now accepts a new keyword argument "supports_response" which has the same semantics as the argument of the same name of the underlying home assistant API. When not explicitly given it has a default value of "none".
- The wrapper function of the custom service implementations now awaits the task and returns the return value.

The user can now use the keyword argument "supports_response" to specify whether the service returns a response when creating a service using the @service decorator:

```
@service(supports_response = "only")
def myservice():
    return {"response_data1": "somedata1", "response_data2": "somedata2"}

```
 The argument "supports_response" accepts the same values as the underlying home assistant API: "none" when no response is returned, "optional" when optionally a response can be returned or "only" when a response must be returned. Default value of "supports_response" is "none".