### PR TITLE
Fix import of Event

### DIFF
--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
 from homeassistant.core import Config, HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import Event as HAEvent
+from homeassistant.core import Event as HAEvent
 from homeassistant.helpers.restore_state import DATA_RESTORE_STATE
 from homeassistant.loader import bind_hass
 


### PR DESCRIPTION
The Event class should have been imported from `homeassistant.core` (as per Frenck), and the current import breaks in 2023.8.  This change makes PyScript work properly in 2023.8.