### PR TITLE
add virtual attribute StateVal.entity_id

### DIFF
--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -1310,8 +1310,8 @@ class AstEval:
                     }
                 )
             for ctx in ctx_list:
+                value = await self.call_func(ctx["enter"], enter_attr, ctx["manager"])
                 if ctx["target"]:
-                    value = await self.call_func(ctx["enter"], enter_attr, ctx["manager"])
                     await self.recurse_assign(ctx["target"], value)
             for arg1 in arg.body:
                 val = await self.aeval(arg1)

--- a/custom_components/pyscript/state.py
+++ b/custom_components/pyscript/state.py
@@ -13,7 +13,7 @@ from .function import Function
 
 _LOGGER = logging.getLogger(LOGGER_PATH + ".state")
 
-STATE_VIRTUAL_ATTRS = {"last_changed", "last_updated"}
+STATE_VIRTUAL_ATTRS = {"entity_id", "last_changed", "last_updated"}
 
 
 class StateVal(str):
@@ -23,6 +23,7 @@ class StateVal(str):
         """Create a new instance given a state variable."""
         new_var = super().__new__(cls, state.state)
         new_var.__dict__ = state.attributes.copy()
+        new_var.entity_id = state.entity_id
         new_var.last_updated = state.last_updated
         new_var.last_changed = state.last_changed
         return new_var

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -258,9 +258,10 @@ Here's an example using ``input_number``, assuming it has been configured to cre
    input_number.test.set_value(value=13)
    input_number.test.set_value(13)
 
-Two additional virtual attribute values are available when you use a variable directly as
+Three additional virtual attribute values are available when you use a variable directly as
 ``DOMAIN.entity.attr`` or call ``state.get("DOMAIN.entity.attr")``:
 
+- ``entity_id`` is the DOMAIN.entity as string
 - ``last_changed`` is the last UTC time the state value was changed (not the attributes)
 - ``last_updated`` is the last UTC time the state entity was updated
 


### PR DESCRIPTION
Modifying StateVal according to homeassistant.core.State. Useful in complex logic: no need to store and pass entity_id.
Simplified example:
```python
def func(state):
    num_seconds_ago = (dt.now(tz=timezone.utc) - state.last_changed).total_seconds()
    if num_seconds_ago > 10:
        light.toggle(entity_id=state.entity_id)
        log.info(f"toggle {state.entity_id}")
```