### PR TITLE
Webhook Trigger

### DIFF
--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -51,6 +51,7 @@ from .mqtt import Mqtt
 from .requirements import install_requirements
 from .state import State, StateVal
 from .trigger import TrigTime
+from .webhook import Webhook
 
 _LOGGER = logging.getLogger(LOGGER_PATH)
 
@@ -241,6 +242,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     Mqtt.init(hass)
     TrigTime.init(hass)
     State.init(hass)
+    Webhook.init(hass)
     State.register_functions()
     GlobalContextMgr.init()
 

--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -21,10 +21,9 @@ from homeassistant.const import (
     EVENT_STATE_CHANGED,
     SERVICE_RELOAD,
 )
-from homeassistant.core import Config, HomeAssistant, ServiceCall
+from homeassistant.core import Config, Event as HAEvent, HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
-from homeassistant.core import Event as HAEvent
 from homeassistant.helpers.restore_state import DATA_RESTORE_STATE
 from homeassistant.loader import bind_hass
 

--- a/custom_components/pyscript/entity.py
+++ b/custom_components/pyscript/entity.py
@@ -1,19 +1,19 @@
-"""Entity Classes"""
+"""Entity Classes."""
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import StateType
-from homeassistant.const import STATE_UNKNOWN
 
 
 class PyscriptEntity(RestoreEntity):
-    """Generic Pyscript Entity"""
+    """Generic Pyscript Entity."""
 
     _attr_extra_state_attributes: dict
     _attr_state: StateType = STATE_UNKNOWN
 
     def set_state(self, state):
-        """Set the state"""
+        """Set the state."""
         self._attr_state = state
 
     def set_attributes(self, attributes):
-        """Set Attributes"""
+        """Set Attributes."""
         self._attr_extra_state_attributes = attributes

--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -75,6 +75,8 @@ TRIGGER_KWARGS = {
     "trigger_time",
     "var_name",
     "value",
+    "webhook_id",
+    "webhook_data",
 }
 
 

--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -79,6 +79,13 @@ TRIGGER_KWARGS = {
     "webhook_data",
 }
 
+WEBHOOK_METHODS = {
+    "GET",
+    "HEAD",
+    "POST",
+    "PUT",
+}
+
 
 def ast_eval_exec_factory(ast_ctx, mode):
     """Generate a function that executes eval() or exec() with given ast_ctx."""
@@ -526,6 +533,10 @@ class EvalFunc:
                     async_set_service_schema(Function.hass, domain, name, service_desc)
                     self.trigger_service.add(srv_name)
                 continue
+
+            if dec_name == "webhook_trigger" and "methods" in dec_kwargs:
+                if len(bad := set(dec_kwargs["methods"]).difference(WEBHOOK_METHODS)) > 0:
+                    raise TypeError(f"{exc_mesg}: {bad} aren't valid {dec_name} methods")
 
             if dec_name not in trig_decs:
                 trig_decs[dec_name] = []

--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -50,6 +50,7 @@ TRIG_DECORATORS = {
     "state_trigger",
     "event_trigger",
     "mqtt_trigger",
+    "webhook_trigger",
     "state_active",
     "time_active",
     "task_unique",
@@ -363,6 +364,7 @@ class EvalFunc:
             "mqtt_trigger",
             "state_trigger",
             "time_trigger",
+            "webhook_trigger",
         }
         arg_check = {
             "event_trigger": {"arg_cnt": {1, 2, 3}, "rep_ok": True},
@@ -373,6 +375,8 @@ class EvalFunc:
             "task_unique": {"arg_cnt": {1, 2}},
             "time_active": {"arg_cnt": {"*"}},
             "time_trigger": {"arg_cnt": {0, "*"}, "rep_ok": True},
+            # TODO: Add in functionality to webhook with arguments
+            "webhook_trigger": {"arg_cnt": {1, 2, 3}, "rep_ok": True},
         }
         kwarg_check = {
             "event_trigger": {"kwargs": {dict}},
@@ -388,6 +392,8 @@ class EvalFunc:
                 "state_hold_false": {int, float},
                 "watch": {set, list},
             },
+            # "webhook_trigger": {"call": {str, list}, "local": bool},
+            "webhook_trigger": {"kwargs": {dict}},
         }
 
         for dec in self.decorators:

--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -377,8 +377,7 @@ class EvalFunc:
             "task_unique": {"arg_cnt": {1, 2}},
             "time_active": {"arg_cnt": {"*"}},
             "time_trigger": {"arg_cnt": {0, "*"}, "rep_ok": True},
-            # TODO: Add in functionality to webhook with arguments
-            "webhook_trigger": {"arg_cnt": {1, 2, 3}, "rep_ok": True},
+            "webhook_trigger": {"arg_cnt": {1, 2}, "rep_ok": True},
         }
         kwarg_check = {
             "event_trigger": {"kwargs": {dict}},
@@ -394,8 +393,11 @@ class EvalFunc:
                 "state_hold_false": {int, float},
                 "watch": {set, list},
             },
-            # "webhook_trigger": {"call": {str, list}, "local": bool},
-            "webhook_trigger": {"kwargs": {dict}},
+            "webhook_trigger": {
+                "kwargs": {dict},
+                "local_only": {bool},
+                "methods": {list, set},
+            },
         }
 
         for dec in self.decorators:

--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -76,7 +76,6 @@ TRIGGER_KWARGS = {
     "var_name",
     "value",
     "webhook_id",
-    "webhook_data",
 }
 
 WEBHOOK_METHODS = {

--- a/custom_components/pyscript/trigger.py
+++ b/custom_components/pyscript/trigger.py
@@ -224,6 +224,8 @@ class TrigTime:
         event_trigger=None,
         mqtt_trigger=None,
         webhook_trigger=None,
+        webhook_local_only=True,
+        webhook_methods=None,
         timeout=None,
         state_hold=None,
         state_hold_false=None,
@@ -374,6 +376,10 @@ class TrigTime:
                     if len(state_trig_ident) > 0:
                         State.notify_del(state_trig_ident, notify_q)
                     raise exc
+            if webhook_methods is None:
+                webhook_methods = {"POST", "PUT"}
+            Webhook.notify_add(webhook_trigger[0], webhook_local_only, webhook_methods, notify_q)
+
         time0 = time.monotonic()
 
         if __test_handshake__:

--- a/custom_components/pyscript/webhook.py
+++ b/custom_components/pyscript/webhook.py
@@ -1,0 +1,76 @@
+"""Handles webhooks and notification."""
+
+import logging
+
+from .const import LOGGER_PATH
+
+_LOGGER = logging.getLogger(LOGGER_PATH + ".webhook")
+
+
+class Webhook:
+    """Define webhook functions."""
+
+    #
+    # Global hass instance
+    #
+    hass = None
+
+    #
+    # notify message queues by webhook type
+    #
+    notify = {}
+    notify_remove = {}
+
+    def __init__(self):
+        """Warn on Webhook instantiation."""
+        _LOGGER.error("Webhook class is not meant to be instantiated")
+
+    @classmethod
+    def init(cls, hass):
+        """Initialize Webhook."""
+
+        cls.hass = hass
+
+    @classmethod
+    async def webhook_listener(cls, event):
+        """Listen callback for given webhook which updates any notifications."""
+
+        func_args = {
+            "trigger_type": "event",
+            "event_type": event.event_type,
+            "context": event.context,
+        }
+        func_args.update(event.data)
+        await cls.update(event.event_type, func_args)
+
+    @classmethod
+    def notify_add(cls, webhook_type, queue):
+        """Register to notify for webhooks of given type to be sent to queue."""
+
+        if webhook_type not in cls.notify:
+            cls.notify[webhook_type] = set()
+            _LOGGER.debug("webhook.notify_add(%s) -> adding webhook listener", webhook_type)
+            cls.notify_remove[webhook_type] = cls.hass.bus.async_listen(webhook_type, cls.webhook_listener)
+        cls.notify[webhook_type].add(queue)
+
+    @classmethod
+    def notify_del(cls, webhook_type, queue):
+        """Unregister to notify for webhooks of given type for given queue."""
+
+        if webhook_type not in cls.notify or queue not in cls.notify[webhook_type]:
+            return
+        cls.notify[webhook_type].discard(queue)
+        if len(cls.notify[webhook_type]) == 0:
+            cls.notify_remove[webhook_type]()
+            _LOGGER.debug("webhook.notify_del(%s) -> removing webhook listener", webhook_type)
+            del cls.notify[webhook_type]
+            del cls.notify_remove[webhook_type]
+
+    @classmethod
+    async def update(cls, webhook_type, func_args):
+        """Deliver all notifications for an webhook of the given type."""
+
+        _LOGGER.debug("webhook.update(%s, %s)", webhook_type, func_args)
+        if webhook_type in cls.notify:
+            for queue in cls.notify[webhook_type]:
+                await queue.put(["webhook", func_args.copy()])

--- a/custom_components/pyscript/webhook.py
+++ b/custom_components/pyscript/webhook.py
@@ -2,11 +2,11 @@
 
 import logging
 
-from .const import LOGGER_PATH
-
 from aiohttp import hdrs
 
 from homeassistant.components import webhook
+
+from .const import LOGGER_PATH
 
 _LOGGER = logging.getLogger(LOGGER_PATH + ".webhook")
 
@@ -49,24 +49,24 @@ class Webhook:
         else:
             func_args["webhook_data"] = await request.post()
 
-
         await cls.update(webhook_id, func_args)
 
     @classmethod
-    def notify_add(cls, webhook_id, queue):
+    def notify_add(cls, webhook_id, local_only, methods, queue):
         """Register to notify for webhooks of given type to be sent to queue."""
-
         if webhook_id not in cls.notify:
             cls.notify[webhook_id] = set()
             _LOGGER.debug("webhook.notify_add(%s) -> adding webhook listener", webhook_id)
             webhook.async_register(
                 cls.hass,
-                "webhook",
-                "my_name",
+                "webhook",  # DOMAIN - unclear what this is used for
+                "pyscript",  # NAME - unclear what this is used for
                 webhook_id,
                 cls.webhook_handler,
+                local_only=local_only,
+                allowed_methods=methods,
             )
-            cls.notify_remove[webhook_id] = lambda : webhook.async_unregister(cls.hass, webhook_id)
+            cls.notify_remove[webhook_id] = lambda: webhook.async_unregister(cls.hass, webhook_id)
 
         cls.notify[webhook_id].add(queue)
 

--- a/custom_components/pyscript/webhook.py
+++ b/custom_components/pyscript/webhook.py
@@ -4,6 +4,10 @@ import logging
 
 from .const import LOGGER_PATH
 
+from aiohttp import hdrs
+
+from homeassistant.components import webhook
+
 _LOGGER = logging.getLogger(LOGGER_PATH + ".webhook")
 
 
@@ -32,45 +36,58 @@ class Webhook:
         cls.hass = hass
 
     @classmethod
-    async def webhook_listener(cls, event):
+    async def webhook_handler(cls, hass, webhook_id, request):
         """Listen callback for given webhook which updates any notifications."""
 
         func_args = {
-            "trigger_type": "event",
-            "event_type": event.event_type,
-            "context": event.context,
+            "trigger_type": "webhook",
+            "webhook_id": webhook_id,
         }
-        func_args.update(event.data)
-        await cls.update(event.event_type, func_args)
+
+        if "json" in request.headers.get(hdrs.CONTENT_TYPE, ""):
+            func_args["webhook_data"] = await request.json()
+        else:
+            func_args["webhook_data"] = await request.post()
+
+
+        await cls.update(webhook_id, func_args)
 
     @classmethod
-    def notify_add(cls, webhook_type, queue):
+    def notify_add(cls, webhook_id, queue):
         """Register to notify for webhooks of given type to be sent to queue."""
 
-        if webhook_type not in cls.notify:
-            cls.notify[webhook_type] = set()
-            _LOGGER.debug("webhook.notify_add(%s) -> adding webhook listener", webhook_type)
-            cls.notify_remove[webhook_type] = cls.hass.bus.async_listen(webhook_type, cls.webhook_listener)
-        cls.notify[webhook_type].add(queue)
+        if webhook_id not in cls.notify:
+            cls.notify[webhook_id] = set()
+            _LOGGER.debug("webhook.notify_add(%s) -> adding webhook listener", webhook_id)
+            webhook.async_register(
+                cls.hass,
+                "webhook",
+                "my_name",
+                webhook_id,
+                cls.webhook_handler,
+            )
+            cls.notify_remove[webhook_id] = lambda : webhook.async_unregister(cls.hass, webhook_id)
+
+        cls.notify[webhook_id].add(queue)
 
     @classmethod
-    def notify_del(cls, webhook_type, queue):
+    def notify_del(cls, webhook_id, queue):
         """Unregister to notify for webhooks of given type for given queue."""
 
-        if webhook_type not in cls.notify or queue not in cls.notify[webhook_type]:
+        if webhook_id not in cls.notify or queue not in cls.notify[webhook_id]:
             return
-        cls.notify[webhook_type].discard(queue)
-        if len(cls.notify[webhook_type]) == 0:
-            cls.notify_remove[webhook_type]()
-            _LOGGER.debug("webhook.notify_del(%s) -> removing webhook listener", webhook_type)
-            del cls.notify[webhook_type]
-            del cls.notify_remove[webhook_type]
+        cls.notify[webhook_id].discard(queue)
+        if len(cls.notify[webhook_id]) == 0:
+            cls.notify_remove[webhook_id]()
+            _LOGGER.debug("webhook.notify_del(%s) -> removing webhook listener", webhook_id)
+            del cls.notify[webhook_id]
+            del cls.notify_remove[webhook_id]
 
     @classmethod
-    async def update(cls, webhook_type, func_args):
+    async def update(cls, webhook_id, func_args):
         """Deliver all notifications for an webhook of the given type."""
 
-        _LOGGER.debug("webhook.update(%s, %s)", webhook_type, func_args)
-        if webhook_type in cls.notify:
-            for queue in cls.notify[webhook_type]:
+        _LOGGER.debug("webhook.update(%s, %s)", webhook_id, func_args)
+        if webhook_id in cls.notify:
+            for queue in cls.notify[webhook_id]:
                 await queue.put(["webhook", func_args.copy()])

--- a/custom_components/pyscript/webhook.py
+++ b/custom_components/pyscript/webhook.py
@@ -45,9 +45,11 @@ class Webhook:
         }
 
         if "json" in request.headers.get(hdrs.CONTENT_TYPE, ""):
-            func_args["webhook_data"] = await request.json()
+            func_args["payload"] = await request.json()
         else:
-            func_args["webhook_data"] = await request.post()
+            # Could potentially return multiples of a key - only take the first
+            payload_multidict = await request.post()
+            func_args["payload"] = {k: payload_multidict.getone(k) for k in payload_multidict.keys()}
 
         await cls.update(webhook_id, func_args)
 

--- a/custom_components/pyscript/webhook.py
+++ b/custom_components/pyscript/webhook.py
@@ -59,8 +59,8 @@ class Webhook:
             _LOGGER.debug("webhook.notify_add(%s) -> adding webhook listener", webhook_id)
             webhook.async_register(
                 cls.hass,
-                "webhook",  # DOMAIN - unclear what this is used for
-                "pyscript",  # NAME - unclear what this is used for
+                "pyscript",  # DOMAIN
+                "pyscript",  # NAME
                 webhook_id,
                 cls.webhook_handler,
                 local_only=local_only,

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -787,7 +787,7 @@ Wildcards in topics are supported. The ``topic`` variables will be set to the fu
 the message arrived on.
 
 NOTE: The `MQTT Integration in Home Assistant <https://www.home-assistant.io/integrations/mqtt/>`__
-must be set up to use ``@mqtt_trigger``. 
+must be set up to use ``@mqtt_trigger``.
 
 @state_active
 ^^^^^^^^^^^^^
@@ -856,6 +856,45 @@ you have several ``not`` arguments, they are logically and'ed together, so the a
 true if the current time doesn't match any of the "not" (negative) specifications. ``@time_active``
 allows multiple arguments with and without ``not``. The condition will be met if the current time
 matches any of the positive arguments, and none of the negative arguments.
+
+@webhook_trigger
+^^^^^^^^^^^^^^^^
+
+.. code:: python
+
+    @webhook_trigger(webhook_id, str_expr=None, local_only=True, methods={"POST", "PUT", kwargs=None)
+
+``@webhook_trigger`` listens for calls to a `Home Assistant webhook <https://www.home-assistant.io/docs/automation/trigger/#webhook-trigger>`__
+at `your_hass_url/api/webhook/webhook_id` and triggers whenever a request is made at that endpoint.
+Multiple ``@webhook_trigger`` decorators can be applied to a single function if you want
+to trigger off different mqtt topics.
+
+An optional ``str_expr`` can be used to match against payload message data, and the trigger will only occur
+if that expression evaluates to ``True`` or non-zero. This expression has available these four
+variables:
+
+Setting `local_only` option to `False` will allow request made from anywhere on the internet (as opposed to just locally).
+The methods option needs to be an list or set with elements `GET`, `HEAD`, `POST`, or `PUT`.
+
+- ``trigger_type`` is set to "mqtt"
+- ``webhook_id`` is set to the webhook_id that was called.
+- ``webhook_data`` is the data/json that was sent in the request returned as a `MultiDictProxy <https://aiohttp-kxepal-test.readthedocs.io/en/latest/multidict.html#aiohttp.MultiDictProxy>`__ (ie a python dictionary that allows multiple of the same keys).
+
+When the ``@webhook_trigger`` occurs, those same variables are passed as keyword arguments to the
+function in case it needs them. Additional keyword parameters can be specified by setting the
+optional ``kwargs`` argument to a ``dict`` with the keywords and values.
+
+An simple example looks like
+
+.. code:: python
+
+  @webhook_trigger("myid", kwargs={"extra": 10})
+  def webhook_test(webhook_data, extra):
+      log.info(f"It ran! {webhook_data}, {extra}")
+
+which if called using the curl command `curl -X POST -d 'key1=xyz&key2=abc' hass_url/api/webhook/myid
+bhook` outputs `It ran! <MultiDictProxy('key1': 'xyz', 'key2': 'abc')>, 10`
+
 
 Other Function Decorators
 -------------------------
@@ -1313,6 +1352,13 @@ It takes the following keyword arguments (all are optional):
 - ``mqtt_trigger=None`` can be set to a string or list of two strings, just like
   ``@mqtt_trigger``. The first string is the MQTT topic, and the second string
   (when the setting is a two-element list) is an expression based on the message variables.
+- ``webhook_trigger=None`` can be set to a string or list of two strings, just like
+  ``@webhook_trigger``. The first string is the webhook id, and the second string
+  (when the setting is a two-element list) is an expression based on the message variables.
+- ``webhook_local_only=True`` is used with ``webhook_trigger`` to specify whether to only allow
+  local webhooks.
+- ``webhook_methods={"POST", "PUT"}`` is used with ``webhook_trigger`` to specify allowed webhook
+  request methods.
 - ``timeout=None`` an overall timeout in seconds, which can be floating point.
 - ``state_check_now=True`` if set, ``task.wait_until()`` checks any ``state_trigger``
   immediately to see if it is already ``True``, and will return immediately if so. If
@@ -1566,7 +1612,7 @@ Pyscript supports importing two types of packages or modules:
   will cause all of the module files to be unloaded, and any scripts or apps that import that module
   will be reloaded. Imports of pyscript modules and packages are not affected by the ``allow_all_imports``
   setting - if a file is in the ``<config>/pyscript/modules`` folder then it can be imported.
-  
+
   Package-style layout is also supported where a PACKAGE is defined in
   ``<config>/pyscript/modules/PACKAGE/__init__.py``, and that file can, in turn,
   do relative imports of other files in that same directory. This form is most convenient for

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -886,7 +886,9 @@ An simple example looks like
   def webhook_test(payload, extra):
       log.info(f"It ran! {payload}, {extra}")
 
-which if called using the curl command ``curl -X POST -d 'key1=xyz&key2=abc' hass_url/api/webhook/myid`` outputs ``It ran! <MultiDictProxy('key1': 'xyz', 'key2': 'abc')>, 10``
+which if called using the curl command ``curl -X POST -d 'key1=xyz&key2=abc' hass_url/api/webhook/myid`` outputs ``It ran! {'key1': 'xyz', 'key2': 'abc'}, 10``
+
+NOTE: A webhook_id can only be used by either a built-in Home Assistant automation or pyscript, but not both. Trying to use the same webhook_id in both will result in an error.
 
 Other Function Decorators
 -------------------------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -864,25 +864,19 @@ matches any of the positive arguments, and none of the negative arguments.
 
     @webhook_trigger(webhook_id, str_expr=None, local_only=True, methods={"POST", "PUT", kwargs=None)
 
-``@webhook_trigger`` listens for calls to a `Home Assistant webhook <https://www.home-assistant.io/docs/automation/trigger/#webhook-trigger>`__
-at `your_hass_url/api/webhook/webhook_id` and triggers whenever a request is made at that endpoint.
-Multiple ``@webhook_trigger`` decorators can be applied to a single function if you want
-to trigger off different mqtt topics.
+``@webhook_trigger`` listens for calls to a `Home Assistant webhook <https://www.home-assistant.io/docs/automation/trigger/#webhook-trigger>`__ at ``your_hass_url/api/webhook/webhook_id`` and triggers whenever a request is made at that endpoint. Multiple ``@webhook_trigger`` decorators can be applied to a single function if you want to trigger off different webhook ids.
 
-An optional ``str_expr`` can be used to match against payload message data, and the trigger will only occur
-if that expression evaluates to ``True`` or non-zero. This expression has available these four
+Setting ``local_only`` option to ``False`` will allow request made from anywhere on the internet (as opposed to just on local network).
+The methods option needs to be an list or set with elements ``GET``, ``HEAD``, ``POST``, or ``PUT``.
+
+An optional ``str_expr`` can be used to match against payload message data, and the trigger will only occur if that expression evaluates to ``True`` or non-zero. This expression has available these three
 variables:
 
-Setting `local_only` option to `False` will allow request made from anywhere on the internet (as opposed to just locally).
-The methods option needs to be an list or set with elements `GET`, `HEAD`, `POST`, or `PUT`.
-
-- ``trigger_type`` is set to "mqtt"
+- ``trigger_type`` is set to "webhook"
 - ``webhook_id`` is set to the webhook_id that was called.
 - ``webhook_data`` is the data/json that was sent in the request returned as a `MultiDictProxy <https://aiohttp-kxepal-test.readthedocs.io/en/latest/multidict.html#aiohttp.MultiDictProxy>`__ (ie a python dictionary that allows multiple of the same keys).
 
-When the ``@webhook_trigger`` occurs, those same variables are passed as keyword arguments to the
-function in case it needs them. Additional keyword parameters can be specified by setting the
-optional ``kwargs`` argument to a ``dict`` with the keywords and values.
+When the ``@webhook_trigger`` occurs, those same variables are passed as keyword arguments to the function in case it needs them. Additional keyword parameters can be specified by setting the optional ``kwargs`` argument to a ``dict`` with the keywords and values.
 
 An simple example looks like
 
@@ -892,9 +886,7 @@ An simple example looks like
   def webhook_test(webhook_data, extra):
       log.info(f"It ran! {webhook_data}, {extra}")
 
-which if called using the curl command `curl -X POST -d 'key1=xyz&key2=abc' hass_url/api/webhook/myid
-bhook` outputs `It ran! <MultiDictProxy('key1': 'xyz', 'key2': 'abc')>, 10`
-
+which if called using the curl command ``curl -X POST -d 'key1=xyz&key2=abc' hass_url/api/webhook/myid`` outputs ``It ran! <MultiDictProxy('key1': 'xyz', 'key2': 'abc')>, 10``
 
 Other Function Decorators
 -------------------------
@@ -1352,9 +1344,7 @@ It takes the following keyword arguments (all are optional):
 - ``mqtt_trigger=None`` can be set to a string or list of two strings, just like
   ``@mqtt_trigger``. The first string is the MQTT topic, and the second string
   (when the setting is a two-element list) is an expression based on the message variables.
-- ``webhook_trigger=None`` can be set to a string or list of two strings, just like
-  ``@webhook_trigger``. The first string is the webhook id, and the second string
-  (when the setting is a two-element list) is an expression based on the message variables.
+- ``webhook_trigger=None`` can be set to a string or list of two strings, just like ``@webhook_trigger``. The first string is the webhook id, and the second string (when the setting is a two-element list) is an expression based on the message variables.
 - ``webhook_local_only=True`` is used with ``webhook_trigger`` to specify whether to only allow
   local webhooks.
 - ``webhook_methods={"POST", "PUT"}`` is used with ``webhook_trigger`` to specify allowed webhook

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -862,7 +862,7 @@ matches any of the positive arguments, and none of the negative arguments.
 
 .. code:: python
 
-    @webhook_trigger(webhook_id, str_expr=None, local_only=True, methods={"POST", "PUT", kwargs=None)
+    @webhook_trigger(webhook_id, str_expr=None, local_only=True, methods={"POST", "PUT"}, kwargs=None)
 
 ``@webhook_trigger`` listens for calls to a `Home Assistant webhook <https://www.home-assistant.io/docs/automation/trigger/#webhook-trigger>`__ at ``your_hass_url/api/webhook/webhook_id`` and triggers whenever a request is made at that endpoint. Multiple ``@webhook_trigger`` decorators can be applied to a single function if you want to trigger off different webhook ids.
 
@@ -874,7 +874,7 @@ variables:
 
 - ``trigger_type`` is set to "webhook"
 - ``webhook_id`` is set to the webhook_id that was called.
-- ``webhook_data`` is the data/json that was sent in the request returned as a `MultiDictProxy <https://aiohttp-kxepal-test.readthedocs.io/en/latest/multidict.html#aiohttp.MultiDictProxy>`__ (ie a python dictionary that allows multiple of the same keys).
+- ``payload`` is the data/json that was sent in the request returned as a dictionary.
 
 When the ``@webhook_trigger`` occurs, those same variables are passed as keyword arguments to the function in case it needs them. Additional keyword parameters can be specified by setting the optional ``kwargs`` argument to a ``dict`` with the keywords and values.
 
@@ -883,8 +883,8 @@ An simple example looks like
 .. code:: python
 
   @webhook_trigger("myid", kwargs={"extra": 10})
-  def webhook_test(webhook_data, extra):
-      log.info(f"It ran! {webhook_data}, {extra}")
+  def webhook_test(payload, extra):
+      log.info(f"It ran! {payload}, {extra}")
 
 which if called using the curl command ``curl -X POST -d 'key1=xyz&key2=abc' hass_url/api/webhook/myid`` outputs ``It ran! <MultiDictProxy('key1': 'xyz', 'key2': 'abc')>, 10``
 

--- a/tests/test_decorator_errors.py
+++ b/tests/test_decorator_errors.py
@@ -461,3 +461,23 @@ def func7():
         "TypeError: function 'func7' defined in file.hello: decorator @state_trigger keyword 'watch' should be type list or set"
         in caplog.text
     )
+
+
+@pytest.mark.asyncio
+async def test_webhooks_method(hass, caplog):
+    """Test invalid keyword arguments type generates an error."""
+
+    await setup_script(
+        hass,
+        None,
+        dt(2020, 7, 1, 11, 59, 59, 999999),
+        """
+@webhook_trigger("hook", methods=["bad"])
+def func8():
+    pass
+""",
+    )
+    assert (
+        "TypeError: function 'func8' defined in file.hello: {'bad'} aren't valid webhook_trigger methods"
+        in caplog.text
+    )

--- a/tests/test_decorator_errors.py
+++ b/tests/test_decorator_errors.py
@@ -1,4 +1,5 @@
 """Test pyscript decorator syntax error and eval-time exception reporting."""
+
 from ast import literal_eval
 import asyncio
 from datetime import datetime as dt
@@ -217,7 +218,7 @@ def func4():
 """,
     )
     assert (
-        "func4 defined in file.hello: needs at least one trigger decorator (ie: event_trigger, mqtt_trigger, state_trigger, time_trigger)"
+        "func4 defined in file.hello: needs at least one trigger decorator (ie: event_trigger, mqtt_trigger, state_trigger, time_trigger, webhook_trigger)"
         in caplog.text
     )
 

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -487,6 +487,7 @@ async def test_jupyter_kernel_redefine_func(hass, caplog, socket_enabled):
 @time_trigger("once(2019/9/7 12:00)")
 @state_trigger("pyscript.var1 == '1'")
 @event_trigger("test_event")
+@webhook_trigger("test_hook1")
 def func():
     pass
 123
@@ -504,6 +505,7 @@ def func():
 @time_trigger("once(2019/9/7 13:00)")
 @state_trigger("pyscript.var1 == '1'")
 @event_trigger("test_event2")
+@webhook_trigger("test_hook1")
 def func():
     pass
 321


### PR DESCRIPTION
This PR closes #353  and adds a new webhook trigger defined as,

```python
@webhook_trigger(webhook_id, str_expr=None, local_only=True, methods={"POST", "PUT"}, kwargs=None)
def foo(payload):
    pass
```

When looking into this, I was hoping that webhooks trigger events, but they unfortunately don't leading to this solution. I've been using this for about a week and it seems to be working stably.  I've added a few things to the tests to make sure things at least run. I'm not sure how to actually call a webhook in a test, but happy to do it if there is a way. 

I also added some documentation that hopefully covers everything.

Let me know if any changes or tweaks are needed!