### PR TITLE
adds state.exist classmethod to check whether an entity_id exists

### DIFF
--- a/custom_components/pyscript/state.py
+++ b/custom_components/pyscript/state.py
@@ -423,6 +423,7 @@ class State:
             "state.get_attr": cls.get_attr,  # deprecated form; to be removed
             "state.persist": cls.persist,
             "state.delete": cls.delete,
+            "state.exist": cls.exist,
             "pyscript.config": cls.pyscript_config,
         }
         Function.register(functions)


### PR DESCRIPTION
adds `state.exist` classmethod to check whether an entity_id exists
very handy to check things exist before manipulating them to get rid of the exceptions