### PR TITLE
remove redundant second await in ast_await

### DIFF
--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -2020,10 +2020,7 @@ class AstEval:
 
     async def ast_await(self, arg):
         """Evaluate await expr."""
-        coro = await self.aeval(arg.value)
-        if coro:
-            return await coro
-        return None
+        return await self.aeval(arg.value)
 
     async def get_target_names(self, lhs):
         """Recursively find all the target names mentioned in the AST tree."""

--- a/tests/test_unit_eval.py
+++ b/tests/test_unit_eval.py
@@ -1406,6 +1406,15 @@ foo()
 """,
         ["bar"],
     ],
+    [
+        """
+async def func():
+    return 42
+
+await func()
+""",
+        42,
+    ],
 ]
 
 


### PR DESCRIPTION
Fixes #643, #673

Code to reproduce:
```python
async def test3():
    return "test3"

@time_trigger("startup")
async def test1():
    await test3()
```
`TypeError: object str can't be used in 'await' expression`