### PR TITLE
docs/reference.rst @mqtt_trigger and callbacks

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -774,15 +774,16 @@ on that topic. Multiple ``@mqtt_trigger`` decorators can be applied to a single 
 to trigger off different mqtt topics.
 
 An optional ``str_expr`` can be used to match the MQTT message data, and the trigger will only occur
-if that expression evaluates to ``True`` or non-zero. This expression has available these four
+if that expression evaluates to ``True`` or non-zero. This expression has available these
 variables:
 
 - ``trigger_type`` is set to "mqtt"
 - ``topic`` is set to the topic the message was received on
+- ``qos`` is set to the message QoS.
 - ``payload`` is set to the string payload of the message
 - ``payload_obj`` if the payload was valid JSON, this will be set to the native Python object
-  representing that payload.
-- ``qos`` is set to the message QoS.
+  representing that payload.  A null message will not be converted.  If payload_obj is a
+  required function argument an exception will be thrown, use payload_obj=None.
 
 When the ``@mqtt_trigger`` occurs, those same variables are passed as keyword arguments to the
 function in case it needs them. Additional keyword parameters can be specified by setting the
@@ -792,6 +793,7 @@ Wildcards in topics are supported. The ``topic`` variables will be set to the fu
 the message arrived on.
 
 Wildcards are:
+
 - ``+`` matches a single level in the topic hierarchy.
 - ``#`` matches zero or more levels in the topic hierarchy, can only be last.
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -2146,7 +2146,8 @@ it doesn't faithfully mimic Python.  Here are some areas where pyscript differs 
   won't be able to call that pyscript function unless it uses ``await``, which requires that function to
   be declared ``async``. Unless the Python module is designed to support async callbacks, it is not
   currently possible to have Python modules and packages call pyscript functions. The workaround is
-  to move your callbacks from pyscript and make them native Python functions; see `Importing <#importing>`__.
+  to move your callbacks from pyscript and make them native Python functions; see `Importing <#importing>`__,
+  call a function with the ``@pyscript_compile`` decorator, or a lambda (which is also compiled).
 - Continuing that point, special methods (e.g., ``__eq__``) in a class created in `pyscript` will not work since
   they are async functions and Python will not be able to call them. The two workarounds are to
   use the ``@pyscript_compile`` decorator so the method is compiled to a native (non-async) Python


### PR DESCRIPTION
I just got bit by a couple things and wanted to contribute back to improve the documentation.
I think they are all minor changes or formatting and straight forward.

The biggest hurdle I had was trying to query the history, I was wanting yesterday's value, and everything in Home Assistant is geared around the most recent value.  In my case I was monitoring my car's TPMS and was wanting the leak rate, so now - yesterday.  I tried the Derivative sensor, but it does weighted averages for the time period, and since there's a large block of time each day that the car isn't available to get the pressure completely throws off the average leak rate.

```
instance = get_instance(hass)
future = await instance.async_add_executor_job(history.get_significant_states, hass, start, stop, ids)
```
I see the asyncio Futures page list `print(await fut)` for getting the future value, but that doesn't seem to work.  The best I've done is `future.add_done_callback` with all the drawbacks of needing to pass a compiled python function or lambda, it does work for what I need.