### PR TITLE
Add retain flag to mqtt trigger

### DIFF
--- a/custom_components/pyscript/eval.py
+++ b/custom_components/pyscript/eval.py
@@ -70,6 +70,7 @@ TRIGGER_KWARGS = {
     "payload",
     "payload_obj",
     "qos",
+    "retain",
     "topic",
     "trigger_type",
     "trigger_time",

--- a/custom_components/pyscript/mqtt.py
+++ b/custom_components/pyscript/mqtt.py
@@ -45,6 +45,7 @@ class Mqtt:
                 "topic": mqttmsg.topic,
                 "payload": mqttmsg.payload,
                 "qos": mqttmsg.qos,
+                "retain": mqttmsg.retain,
             }
 
             try:


### PR DESCRIPTION
This Pull Request enhances the `@mqtt_trigger` to fully support the MQTT `retain` flag, passing it as a keyword argument to decorated functions. This allows pyscript automations to differentiate between new and retained messages, enabling more advanced logic.