### PR TITLE
Add StateVal conversion helpers and availability checks

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -231,6 +231,21 @@ the variable ``test1_state`` captures both the value and attributes of ``binary_
 Later, if ``binary_sensor.test1`` changes, ``test1_state`` continues to represent the previous
 value and attributes at the time of the assignment.
 
+Keep in mind that ``test1_state`` (and any other value returned by ``state.get()`` or direct state
+reference) remains a subclass of ``str``. Pyscript exposes several helper methods on these instances
+to simplify conversions and availability checks:
+
+- ``as_float(default=None)``
+- ``as_int(default=None, base=10)``
+- ``as_bool(default=None)``
+- ``as_round(precision=0, method: Literal["common", "ceil", "floor", "half"] = "common", default=None)``
+- ``as_datetime(default=None)``
+- ``is_unknown()`` / ``is_unavailable()`` / ``has_value()``
+
+Each of the ``as_*`` helpers wraps the equivalent forgiving helper from
+``homeassistant.helpers.template``. ``default`` is optional in every case: pass it to get a fallback
+value on failure, or omit it to have a ``ValueError`` raised.
+
 State variables also support virtual methods that are service calls with that ``entity_id``.
 For any state variable ``DOMAIN.ENTITY``, any services registered by ``DOMAIN``, e.g.,
 ``DOMAIN.SERVICE``, that have an ``entity_id`` parameter can be called as a method
@@ -268,7 +283,7 @@ Four additional virtual attribute values are available when you use a variable d
 - ``entity_id`` is the DOMAIN.entity as string
 - ``last_changed`` is the last UTC time the state value was changed (not the attributes)
 - ``last_updated`` is the last UTC time the state entity was updated
-- ``last_reported``is the last UTC time the integration set the state of an entity, regardless of whether it changed or not
+- ``last_reported`` is the last UTC time the integration set the state of an entity, regardless of whether it changed or not
 
 If you need to compute how many seconds ago the ``binary_sensor.test1`` state changed, you could
 do this:


### PR DESCRIPTION
StateVal Helpers

  - New StateVal helpers wrap Home Assistant’s forgiving converters, so `input_number.brightness.as_int(default=0)` or `sensor.timestamp.as_datetime()` just work - no more manual ```int(...)/float(...)``` juggling or wrapping those casts in try/except.
  - Added availability checks: .is_unknown(), .is_unavailable(), and .has_value() replace ad-hoc comparisons with `unavailable/unknown`.
  
Example (for illustration only):
```python
@state_trigger("float(sensor.some_number)>10") #got error on unavailable/unknown
def old_style():
    try:
        sensor_value = int(sensor.another_sensor)
    except Exception:
        sensor_value = 0
    if sensor_value > 10 or binary_sensor.motion == "on":
        try:
            temperature = float(sensor.temperature)
            if temperature > 20:
                if climate.ac not in ["unavailable", "unknown"]: #check device online
                    climate.ac.set_temperature(temperature=sensor_value+10)
        except Exception:
            pass

@state_trigger("sensor.some_number.as_float(default=0)>10") # no error on unavailable/unknown
def new_style():
    sensor_value = sensor.another_sensor.as_int(default=0)
    
    if sensor_value > 10 or binary_sensor.motion.as_bool(False):
        temperature = sensor.temperature.as_float(-100)
        if temperature > 20 and climate.ac.has_value():
            climate.ac.set_temperature(temperature=sensor_value+10)
```