### PR TITLE
Rearrange placement of the encoding argument description in documenta…

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -816,9 +816,6 @@ An optional ``str_expr`` can be used to match the MQTT message data, and the tri
 if that expression evaluates to ``True`` or non-zero. This expression has available these
 variables:
 
-An optional ``encoding`` argument specifies the character encoding used to decode the MQTT payload
-(default is **"utf-8"**). It can be explicitly set to other encodings if necessary.
-
 - ``trigger_type`` is set to "mqtt".
 - ``topic`` is set to the topic the message was received on.
 - ``qos`` is set to the message QoS.
@@ -827,6 +824,9 @@ An optional ``encoding`` argument specifies the character encoding used to decod
   representing that payload.  A null message will not be converted.  If payload_obj is a
   required function argument an exception will be thrown, use payload_obj=None.
 - ``retain`` is set to the message retain flag. True if the message was retained, False otherwise.
+
+An optional ``encoding`` argument specifies the character encoding used to decode the MQTT payload
+(default is **"utf-8"**). It can be explicitly set to other encodings if necessary.
 
 When the ``@mqtt_trigger`` occurs, those same variables are passed as keyword arguments to the
 function in case it needs them. Additional keyword parameters can be specified by setting the


### PR DESCRIPTION
The `encoding` argument description in the reference section was misplaced — moved it to the proper location.
This change only adjusts documentation placement; no functional changes.
Apologies for this oversight being found right after the recent release.