### PR TITLE
fix module context starting before Home Assistant; see #784

### DIFF
--- a/custom_components/pyscript/__init__.py
+++ b/custom_components/pyscript/__init__.py
@@ -133,7 +133,7 @@ def start_global_contexts(global_ctx_only: str = None) -> None:
     start_list = []
     for global_ctx_name, global_ctx in GlobalContextMgr.items():
         idx = global_ctx_name.find(".")
-        if idx < 0 or global_ctx_name[0:idx] not in {"file", "apps", "scripts"}:
+        if idx < 0 or global_ctx_name[0:idx] not in {"file", "apps", "modules", "scripts"}:
             continue
         if global_ctx_only is not None and global_ctx_only != "*":
             if global_ctx_name != global_ctx_only and not global_ctx_name.startswith(global_ctx_only + "."):

--- a/custom_components/pyscript/global_ctx.py
+++ b/custom_components/pyscript/global_ctx.py
@@ -188,7 +188,7 @@ class GlobalContext:
         global_ctx = GlobalContext(
             ctx_name, global_sym_table=mod.__dict__, manager=self.manager, rel_import_path=rel_import_path
         )
-        global_ctx.set_auto_start(True)
+        global_ctx.set_auto_start(self.auto_start)
         _, error_ctx = await self.manager.load_file(global_ctx, file_path)
         if error_ctx:
             _LOGGER.error(


### PR DESCRIPTION
Explanation:
Before this PR, all imported modules were always assigned `auto_start = True`, which caused their triggers to run immediately after the file was loaded:

load files from disk → import modules → module.set_auto_start(True) → run module triggers (including the factories) →
wait for HA startup → run file-level triggers

After this PR, a module inherits the auto_start value of the current context:
	•	If Home Assistant is already running, behavior remains unchanged.
	•	If HA is still starting up, the current context has auto_start == False, and the module receives the same value.
In this case, the module will start later in `start_global_context`, together with all other contexts.