### PR TITLE
Add EvalFuncVar binding via descriptor and drop manual rebinding

### DIFF
--- a/tests/test_unit_eval.py
+++ b/tests/test_unit_eval.py
@@ -181,6 +181,58 @@ class Color(Enum):
     ],
     [
         """
+from enum import Enum
+
+class HomeState(Enum):
+    HOME = "home"
+    AWAY = "away"
+
+    def name_and_value(self):
+        return f"{self.name}:{self.value}"
+
+[HomeState.HOME.name_and_value(), HomeState.AWAY.name_and_value()]
+""",
+        ["HOME:home", "AWAY:away"],
+    ],
+    [
+        """
+class Device:
+    def greet(self, name):
+        return f"hi {name} from {self.__class__.__name__}"
+
+d = Device()
+d.greet("Alice")
+""",
+        "hi Alice from Device",
+    ],
+    [
+        """
+def add(self, x, y=0):
+    return x + y
+
+class Calc:
+    pass
+
+Calc.add = add
+Calc().add(2, 3)
+""",
+        5,
+    ],
+    [
+        """
+class Base:
+    def tag(self):
+        return "base"
+
+class Child(Base):
+    pass
+
+Child().tag()
+""",
+        "base",
+    ],
+    [
+        """
 from dataclasses import dataclass
 
 @dataclass()


### PR DESCRIPTION
Looking into #787 I found that `Enum` overrides `__dir__`, so [dir(inst)](https://github.com/custom-components/pyscript/compare/master...dmamelin:pyscript:evalfuncvar-descriptor-binding?expand=1#diff-733b200d9ce0361a3582c281043fd548b057e971f927f73aed75bfdc8422f06cL1992) inside `call_func` doesn’t show the method.
I went deep into MRO, inspect, etc., but the actual fix turned out to be much simpler: [descriptors](https://docs.python.org/3/howto/descriptor.html) solve this problem.
[CPython implementation](https://github.com/python/cpython/blob/main/Objects/funcobject.c#L1199)

A quick search shows that `__dir__` is rarely overridden, but this PR may also affect other class-related issues in Pyscript - I just don’t know which ones yet :)

The logic for creating `EvalFuncVarClassInst` has also changed. Previously, an `EvalFuncVarClassInst` was created for every available `EvalFuncVar` method when the instance was constructed.
Now, no `EvalFuncVarClassInst` objects are created during instance construction; instead, a new `EvalFuncVarClassInst` is created on each access to an EvalFuncVar.

```python
class Test:
    def a(self):
        pass

    def b(self):
        pass

def old():
    test = Test()  # AstEval.call_func: create EvalFuncVarClassInst for a() and b()
    test.a()       # use existing EvalFuncVarClassInst
    test.a()       # use existing EvalFuncVarClassInst

def new():
    test = Test()  # AstEval.call_func: _NO_ EvalFuncVarClassInst created
    test.a()       # create EvalFuncVarClassInst and call it
    test.a()       # create a new EvalFuncVarClassInst and call it
    b = test.a     # create EvalFuncVarClassInst
    b()            # call the existing EvalFuncVarClassInst
```