### PR TITLE
DM fixes (task.wait_until & typo in time_trigger)

### DIFF
--- a/custom_components/pyscript/decorator.py
+++ b/custom_components/pyscript/decorator.py
@@ -29,6 +29,21 @@ from .state import State
 
 _LOGGER = logging.getLogger(__name__)
 
+LEGACY_WAIT_UNTIL_ARGS = [
+    "state_trigger",
+    "state_check_now",
+    "time_trigger",
+    "event_trigger",
+    "mqtt_trigger",
+    "mqtt_trigger_encoding",
+    "webhook_trigger",
+    "webhook_local_only",
+    "webhook_methods",
+    "timeout",
+    "state_hold",
+    "state_hold_false",
+]
+
 
 class DecoratorRegistry:
     """Decorator registry."""
@@ -102,8 +117,22 @@ class DecoratorRegistry:
         return None
 
     @classmethod
-    async def wait_until(cls, ast_ctx: AstEval, *_arg: Any, **kwargs: Any) -> Any:
+    async def wait_until(cls, ast_ctx: AstEval, *args: Any, **kwargs: Any) -> Any:
         """Build a temporary decorator manager that waits until one of trigger decorators fires."""
+
+        if len(args) > 0:
+            # Preserve legacy positional arguments for now; reject them in a future release.
+            ast_ctx.get_logger().warning(
+                "Ambiguous positional arguments in task.wait_until%s; use keyword arguments instead",
+                args,
+            )
+            kwargs = kwargs.copy()
+            for i, arg in enumerate(args):
+                key = LEGACY_WAIT_UNTIL_ARGS[i]
+                if key in kwargs:
+                    raise TypeError(f"task.wait_until() got multiple values for argument '{key}'")
+                kwargs[key] = arg
+
         func_args = set(kwargs.keys())
         if len(func_args) == 0:
             return {"trigger_type": "none"}

--- a/custom_components/pyscript/decorators/timing.py
+++ b/custom_components/pyscript/decorators/timing.py
@@ -77,7 +77,7 @@ class TimeTriggerDecorator(TriggerDecorator):
     run_on_startup: bool = False
     run_on_shutdown: bool = False
     timespec: list[str]
-    _cycle_task: asyncio.Task
+    _cycle_task: asyncio.Task = None
 
     async def validate(self) -> None:
         """Validate the decorator arguments."""

--- a/custom_components/pyscript/stubs/pyscript_builtins.py
+++ b/custom_components/pyscript/stubs/pyscript_builtins.py
@@ -438,6 +438,7 @@ class task:
 
     @staticmethod
     def wait_until(
+        *,
         state_trigger: str | list[str] | None = None,
         time_trigger: str | list[str] | None = None,
         event_trigger: str | list[str] | None = None,


### PR DESCRIPTION
#839
The documentation says that `task.wait_until` supports keyword arguments. In practice, however, positional arguments were also supported, so code like `task.wait_until("input_boolean.test1 == 'off'")` was valid and worked.

I added temporary support for this in DM and updated the stubs.