### PR TITLE
Fix get_astral_location deprecation warning

### DIFF
--- a/custom_components/pyscript/trigger.py
+++ b/custom_components/pyscript/trigger.py
@@ -12,6 +12,7 @@ import time
 
 from croniter import croniter
 
+from homeassistant.const import SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
 from homeassistant.core import Context
 from homeassistant.helpers import sun
 from homeassistant.util import dt as dt_util
@@ -672,28 +673,15 @@ class TrigTime:
             else:
                 hour, mins, sec = int(match0[1]), int(match0[2]), 0
             dt_str = dt_str[len(match0.group(0)) :]
-        elif dt_str.startswith("sunrise") or dt_str.startswith("sunset"):
-            location = sun.get_astral_location(cls.hass)
-            if isinstance(location, tuple):
-                # HA core-2021.5.0 included this breaking change: https://github.com/home-assistant/core/pull/48573.
-                # As part of the upgrade to astral 2.2, sun.get_astral_location() now returns a tuple including the
-                # elevation.  We just want the astral.location.Location object.
-                location = location[0]
-            try:
-                if dt_str.startswith("sunrise"):
-                    time_sun = await cls.hass.async_add_executor_job(
-                        location.sunrise, dt.date(year, month, day)
-                    )
-                    dt_str = dt_str[7:]
-                else:
-                    time_sun = await cls.hass.async_add_executor_job(
-                        location.sunset, dt.date(year, month, day)
-                    )
-                    dt_str = dt_str[6:]
-            except Exception:
+        elif dt_str.startswith(SUN_EVENT_SUNRISE) or dt_str.startswith(SUN_EVENT_SUNSET):
+            event = SUN_EVENT_SUNRISE if dt_str.startswith(SUN_EVENT_SUNRISE) else SUN_EVENT_SUNSET
+            time_sun = sun.get_astral_event_date(cls.hass, event, dt.date(year, month, day))
+            if time_sun is None:
                 _LOGGER.warning("'%s' not defined at this latitude", dt_str)
                 # return something in the past so it is ignored
                 return now - dt.timedelta(days=100), fixed_date
+            time_sun = dt_util.as_local(time_sun)
+            dt_str = dt_str[len(event) :]
             now += time_sun.date() - now.date()
             hour, mins, sec = time_sun.hour, time_sun.minute, time_sun.second
         elif dt_str.startswith("noon"):

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -2035,21 +2035,20 @@ You can use ``hass`` to compute sunrise and sunset times using the same method H
 .. code:: python
 
    import homeassistant.helpers.sun as sun
+   import homeassistant.util.dt as dt_util
    import datetime
 
-   location = sun.get_astral_location(hass)
-   sunrise = location[0].sunrise(datetime.datetime.today()).replace(tzinfo=None)
-   sunset = location[0].sunset(datetime.datetime.today()).replace(tzinfo=None)
+   date = datetime.date.today()
+   sunrise = dt_util.as_local(sun.get_astral_event_date(hass, "sunrise", date)).replace(tzinfo=None)
+   sunset = dt_util.as_local(sun.get_astral_event_date(hass, "sunset", date)).replace(tzinfo=None)
    print(f"today sunrise = {sunrise}, sunset = {sunset}")
 
 (Note that the ``sun.sun`` attributes already provide times for the next sunrise and sunset, so
-this example is a bit contrived.  Also note this only applies to HA 2021.5 and later; prior
-to that, ``sun.get_astral_location()`` doesn't return the elevation, so replace ``location[0]``
-with ``location`` in the two expressions if you have an older version of HA.)
+this example is a bit contrived.  The ``sun.get_astral_event_date()`` helper returns the time in
+UTC, so ``dt_util.as_local()`` converts it to local time.)
 
 Here's another method that uses the installed version of ``astral`` directly, rather than the HASS
-helper function. HA 2021.5 upgraded to ``astral 2.2``, and here's one way of getting sunrise
-using this version (prior to this HA used a very old version of ``astral``).
+helper function (note this does not account for your configured elevation):
 
 .. code:: python
 


### PR DESCRIPTION
`sunrise`/`sunset` triggers used `sun.get_astral_location()`, which HA deprecated (removal in 2027.7) and warned on every use. Switched to the higher-level `sun.get_astral_event_date()`, which avoids the deprecated API entirely and needs no version fallback.

This also restores `elevation` support, which was inadvertently dropped in 300a633 when a local `get_astral_event_date` copy omitted the `observer_elevation` argument. No behavior change at the default elevation of 0; existing tests pass.

On dropping `async_add_executor_job`: the executor wrapping was added in 884c428 (PR #610) to move the blocking `location.sunrise()`/`sunset()` calls (timezone data loaded from disk) off the event loop. That's no longer needed here: `get_astral_event_date()` is a HA `@callback` (loop-safe by contract, and called synchronously by HA itself), and it computes in `UTC` - the local conversion uses the timezone already cached at startup via `dt_util.as_local()`. So the call runs directly on the loop without reintroducing the blocking I/O.

Fixes #858.