### PR TITLE
Exposes the `request.headers` to the `webhook_trigger` function arguments. 

### DIFF
--- a/custom_components/pyscript/webhook.py
+++ b/custom_components/pyscript/webhook.py
@@ -42,6 +42,7 @@ class Webhook:
         func_args = {
             "trigger_type": "webhook",
             "webhook_id": webhook_id,
+            "headers": request.headers,
         }
 
         if "json" in request.headers.get(hdrs.CONTENT_TYPE, ""):


### PR DESCRIPTION
### Description
This PR exposes the `request.headers` to the `webhook_trigger` function arguments. 

### Motivation and Context
Currently, it's not possible to perform security validations (like verifying HMAC signatures from GitHub or Shopify webhooks) because the raw request headers are omitted when the webhook trigger executes. Passing `headers` into `func_args` fixes this limitation.

### How Has This Been Tested?
Tested locally by capturing `kwargs.get("headers")` inside a Pyscript webhook function and successfully validating incoming request signatures.
