### PR TITLE
fix(webhook): restore aiohttp request in legacy webhook func_args

### DIFF
--- a/custom_components/pyscript/webhook.py
+++ b/custom_components/pyscript/webhook.py
@@ -42,6 +42,7 @@ class Webhook:
         func_args = {
             "trigger_type": "webhook",
             "webhook_id": webhook_id,
+            "request": request,
         }
 
         if "json" in request.headers.get(hdrs.CONTENT_TYPE, ""):

--- a/tests/test_decorator_errors.py
+++ b/tests/test_decorator_errors.py
@@ -3,12 +3,13 @@
 from ast import literal_eval
 import asyncio
 from datetime import datetime as dt
-from unittest.mock import mock_open, patch
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
 
 from custom_components.pyscript import trigger
 from custom_components.pyscript.const import DOMAIN
+from custom_components.pyscript.decorators.webhook import WebhookTriggerDecorator
 from custom_components.pyscript.function import Function
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_STATE_CHANGED
 from homeassistant.setup import async_setup_component
@@ -212,7 +213,32 @@ def func4():
         in caplog.text
     )
 
+@pytest.mark.asyncio
+async def test_webhook_request_kwarg(hass):
+    """The aiohttp request is passed to the user function as the `request` kwarg."""
+    notify_q = asyncio.Queue(0)
+    await setup_script(
+        hass,
+        notify_q,
+        [dt(2020, 7, 1, 11, 59, 59, 999999)],
+        """
+@webhook_trigger("test_req_hook")
+def webhook_test(payload, request):
+    pyscript.done = [request.headers["X-My-Sig"], request.method, payload]
+""",
+    )
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
 
+    request = MagicMock()
+    request.headers = {"Content-Type": "application/json", "X-My-Sig": "abc123"}
+    request.method = "POST"
+    request.json = AsyncMock(return_value={"hello": "world"})
+
+    await WebhookTriggerDecorator._handler(hass, "test_req_hook", request)
+
+    assert literal_eval(await wait_until_done(notify_q)) == ["abc123", "POST", {"hello": "world"}]
+    
 @pytest.mark.asyncio
 async def test_trigger_expression_errors(hass, caplog, monkeypatch):
     """Legacy trigger expression errors should not stop trigger loops."""


### PR DESCRIPTION
Restores request in the kwargs payload built by the legacy webhook handler.

Why:

User webhook functions may need direct access to aiohttp request
(headers, method, query and raw body).
This is required for HMAC/signature validation and advanced webhook checks.
Aligns behavior with decorators/webhook.py (commit 5612dd4), which already
exposes request to webhook trigger functions.
Compatibility:

Backward compatible for scripts that do not declare request.
Comandos prontos para commit:

cd /home/grassato/workspace/pyscript
git add custom_components/pyscript/webhook.py
git commit -m "fix(webhook): restore aiohttp request in legacy webhook func_args" -m "Restores request in the kwargs payload built by the legacy webhook handler.
Why:

User webhook functions may need direct access to aiohttp request (headers, method, query and raw body).
This is required for HMAC/signature validation and advanced webhook checks.
Aligns behavior with decorators/webhook.py (commit 5612dd4), which already exposes request to webhook trigger functions.
Compatibility:

Backward compatible for scripts that do not declare request."